### PR TITLE
Reassign hotkeys and simplify text replacement workflow

### DIFF
--- a/GhostType requierement.MD
+++ b/GhostType requierement.MD
@@ -46,17 +46,17 @@ Designed specifically for virtual world chat (Firestorm) but works anywhere
 
 Three Operating Modes
 
-Mode 1 — Correct (F3)
+Mode 1 — Correct (F6)
 
 Detects the language of the typed text (French or English). Fixes all spelling, grammar, and syntax errors. Preserves the original meaning and language. Returns only the corrected text. This is the core use case.
 
-Mode 2 — Translate (F4)
+Mode 2 — Translate (F7)
 
 Translates the typed text to the configured target language. Auto-detects source language. User configures default target language in config.json. Useful for switching between French and English chat in Firestorm.
 
-Mode 3 — Rewrite (Ctrl+F3)
+Mode 3 — Rewrite (F8)
 
-Sends the typed text to the LLM with a creative prompt template. User cycles through available templates with Ctrl+F4. Templates are fully configurable in config.json. Examples: funny reply, formal tone, sarcastic, flirty, poetic, ELI5, pirate speak, or any custom prompt the user defines.
+Sends the typed text to the LLM with a creative prompt template. User cycles through available templates with Ctrl+F8. Templates are fully configurable in config.json. Examples: funny reply, formal tone, sarcastic, flirty, poetic, ELI5, pirate speak, or any custom prompt the user defines.
 
 
 
@@ -66,17 +66,17 @@ Full Hotkey Map
 
 
 
-F3: Capture text and send for correction (Mode 1)
+F6: Capture text and send for correction (Mode 1)
 
-F4: Capture text and send for translation (Mode 2)
+F7: Capture text and send for translation (Mode 2)
 
-Ctrl+F3: Capture text and send for rewrite using active template (Mode 3)
+F8: Capture text and send for rewrite using active template (Mode 3)
 
-Ctrl+F4: Cycle through rewrite templates (overlay shows current template name)
+Ctrl+F8: Cycle through rewrite templates (overlay shows current template name)
 
-F5: Accept and replace original text with result
+Escape: Cancel in-progress operation
 
-Escape: Dismiss overlay and cancel pending operation
+Ctrl+Z: Undo replacement (native, handled by target app)
 
 
 
@@ -86,7 +86,7 @@ Detailed Flow
 
 User types text in target application chat input field.
 
-User presses the hotkey for the desired mode (F3, F4, or Ctrl+F3).
+User presses the hotkey for the desired mode (F6, F7, or F8).
 
 Service selects all text in chat input (Ctrl+A), copies to clipboard (Ctrl+C), reads clipboard.
 
@@ -96,11 +96,32 @@ Service receives the result from the LLM.
 
 Overlay window appears near the chat input showing the result. For correction mode, changed words are highlighted. For translation mode, the full translation is shown. For rewrite mode, the rewritten text is shown with the template name.
 
-User presses F5 to accept: service selects all text in chat input (Ctrl+A), pastes the result from memory, dismisses overlay.
+Result auto-replaces the original text. User presses Ctrl+Z (native undo) to revert if needed.
 
-User presses Escape to dismiss: clears stored result, hides overlay, no changes made.
+User presses Escape to cancel: clears stored result, hides overlay, no changes made.
 
 
+
+
+
+Default Hotkey Rationale
+
+F6, F7, and F8 were chosen as the default hotkeys because they are three consecutive function keys that are virtually unused across Windows, Linux, and macOS applications, making them safe defaults with near-zero conflict risk.
+
+Why other function keys were avoided:
+
+F1 — Help in nearly every application
+F2 — Rename (Explorer, IDEs, spreadsheets)
+F3 — Search/Find in browsers, Explorer, and many editors
+F4 — Mostly safe alone, but Alt+F4 closes windows, creating accidental-close risk
+F5 — Refresh in browsers and Explorer
+F10 — Activates the menu bar in most Windows applications
+F11 — Fullscreen toggle in browsers and many apps
+F12 — Developer tools in browsers, Save As in Office
+
+F6, F7, and F8 have no standard system-wide or application-wide bindings, making them ideal for a background service that must coexist with other software.
+
+All hotkeys are fully configurable in config.json, so users can remap them to any key combination if needed.
 
 
 
@@ -162,15 +183,13 @@ Configuration File (config.json)
 
 &nbsp; "hotkeys": {
 
-&nbsp;   "correct": "F3",
+&nbsp;   "correct": "F6",
 
-&nbsp;   "translate": "F4",
+&nbsp;   "translate": "F7",
 
-&nbsp;   "rewrite": "Ctrl+F3",
+&nbsp;   "rewrite": "F8",
 
-&nbsp;   "cycle\_template": "Ctrl+F4",
-
-&nbsp;   "apply": "F5",
+&nbsp;   "cycle\_template": "Ctrl+F8",
 
 &nbsp;   "cancel": "Escape"
 
@@ -308,9 +327,7 @@ System tray icon for quick access
 
 JSON config file for LLM provider, API key, model, hotkeys
 
-F3 hotkey for correction mode only
-
-F5 hotkey to replace text
+F6 hotkey for correction mode only
 
 Escape to cancel
 
@@ -332,7 +349,7 @@ v0.2 — Translation and Overlay
 
 
 
-Add translation mode (F4)
+Add translation mode (F7)
 
 Transparent overlay window replaces the app window for showing results
 
@@ -350,9 +367,9 @@ v0.3 — Rewrite Mode and Polish
 
 
 
-Add rewrite mode (Ctrl+F3) with configurable templates
+Add rewrite mode (F8) with configurable templates
 
-Template cycling (Ctrl+F4)
+Template cycling (Ctrl+F8)
 
 Config hot-reload without restart
 
@@ -444,7 +461,7 @@ Performance Targets
 
 Hotkey response time: < 50ms from keypress to API call initiated
 
-Total correction cycle (F3 to result ready): < 3 seconds (network dependent)
+Total correction cycle (F6 to result ready): < 3 seconds (network dependent)
 
 Overlay render time: < 100ms
 
@@ -508,9 +525,9 @@ Unit tests for LLM API request/response formatting per provider (Anthropic, Open
 
 Unit tests for mode routing logic
 
-Integration test: mock LLM API, verify full F3 to F5 cycle
+Integration test: mock LLM API, verify full F6 correction cycle
 
-Integration test: mock LLM API, verify F4 translation cycle
+Integration test: mock LLM API, verify F7 translation cycle
 
 Manual testing in Firestorm on Windows
 
@@ -620,7 +637,7 @@ How to Use This Spec with Claude Code
 
 Open Claude Code in your project directory and paste this prompt:
 
-"Read the specification document GhostType\_Spec.md and build the MVP (v0.1). This is a Windows desktop application in Go. Start with the project structure and go.mod, then implement each module in this order: (1) config loading and validation with tests, (2) LLM client interface with Anthropic and OpenAI implementations and tests, (3) clipboard read/write, (4) Windows window detection for Firestorm, (5) Windows keyboard hooks for F3, F5, and Escape, (6) main app window UI showing results, (7) system tray icon, (8) main.go wiring everything together. Only implement correction mode (F3) for the MVP. Target Windows only. Use Fyne for the GUI."
+"Read the specification document GhostType\_Spec.md and build the MVP (v0.1). This is a Windows desktop application in Go. Start with the project structure and go.mod, then implement each module in this order: (1) config loading and validation with tests, (2) LLM client interface with Anthropic and OpenAI implementations and tests, (3) clipboard read/write, (4) Windows window detection for Firestorm, (5) Windows keyboard hooks for F6 and Escape, (6) main app window UI showing results, (7) system tray icon, (8) main.go wiring everything together. Only implement correction mode (F6) for the MVP. Target Windows only. Use Fyne for the GUI."
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 GhostType is a lightweight background service that hooks into your chat application (primarily Firestorm Second Life viewer) and provides real-time spelling correction, language translation, and creative text rewriting — powered by your choice of LLM provider.
 
-Type in French, hit **F3**, get it corrected. Switch to English, hit **F3**, corrected too. Need to translate? **F4**. Want a funny reply? **Ctrl+F3**. Accept with **F5** or dismiss with **Escape**. That simple.
+Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, corrected too. Need to translate? **F7**. Want a funny reply? **F8**. Undo with **Ctrl+Z** or cancel with **Escape**. That simple.
 
 ---
 
@@ -34,7 +34,7 @@ Type in French, hit **F3**, get it corrected. Switch to English, hit **F3**, cor
 - **Translate** — Instantly translates between French and English (or any configured language pair)
 - **Rewrite** — Rewrites your text using customizable prompt templates (funny, formal, sarcastic, flirty, poetic, and more)
 - **Multi-Provider** — Works with Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, or local Ollama models
-- **Hotkey Driven** — F3 to correct, F4 to translate, Ctrl+F3 to rewrite, F5 to accept, Escape to cancel
+- **Hotkey Driven** — F6 to correct, F7 to translate, F8 to rewrite, Ctrl+F8 to cycle templates, Escape to cancel
 - **Configurable** — JSON config file for API keys, providers, hotkeys, prompts, overlay settings, and custom rewrite templates
 - **Lightweight** — Single binary, runs in the background, under 50 MB memory, near-zero CPU at idle
 - **Cross-Platform** — Windows first, Linux and macOS coming in future releases
@@ -65,7 +65,7 @@ On first run, GhostType creates a default `config.json` in the same directory. O
 ghosttype.exe
 ```
 
-GhostType starts minimized in your system tray. Open Firestorm, type something in chat, and press **F3**.
+GhostType starts minimized in your system tray. Open Firestorm, type something in chat, and press **F6**.
 
 ---
 
@@ -73,12 +73,12 @@ GhostType starts minimized in your system tray. Open Firestorm, type something i
 
 | Hotkey | Action |
 |--------|--------|
-| **F3** | Correct spelling and grammar |
-| **F4** | Translate to target language |
-| **Ctrl+F3** | Rewrite using active template |
-| **Ctrl+F4** | Cycle through rewrite templates |
-| **F5** | Accept and replace text |
-| **Escape** | Dismiss and cancel |
+| **F6** | Correct spelling and grammar |
+| **F7** | Translate to target language |
+| **F8** | Rewrite using active template |
+| **Ctrl+F8** | Cycle through rewrite templates |
+| **Escape** | Cancel in-progress operation |
+| **Ctrl+Z** | Undo replacement (native) |
 
 All hotkeys are configurable in `config.json`.
 
@@ -97,11 +97,10 @@ GhostType is configured entirely through `config.json`. Here is a full example:
   "languages": ["fr", "en"],
   "default_translate_target": "en",
   "hotkeys": {
-    "correct": "F3",
-    "translate": "F4",
-    "rewrite": "Ctrl+F3",
-    "cycle_template": "Ctrl+F4",
-    "apply": "F5",
+    "correct": "F6",
+    "translate": "F7",
+    "rewrite": "F8",
+    "cycle_template": "Ctrl+F8",
     "cancel": "Escape"
   },
   "target_window": "Firestorm",
@@ -158,7 +157,7 @@ You can add your own rewrite styles by editing the `rewrite_templates` array in 
 }
 ```
 
-Cycle through templates in real-time with **Ctrl+F4**. The overlay shows which template is currently active.
+Cycle through templates in real-time with **Ctrl+F8**. The overlay shows which template is currently active.
 
 ---
 
@@ -193,7 +192,7 @@ go test ./...
 3. When you press a hotkey, it selects all text in the active chat input, copies it to clipboard, and reads it.
 4. The text is sent to your configured LLM provider with the appropriate prompt.
 5. The corrected/translated/rewritten result appears in an overlay near the chat input.
-6. Press **F5** to accept (replaces your original text) or **Escape** to dismiss.
+6. The result auto-replaces your text. Press **Escape** to cancel, or **Ctrl+Z** to undo.
 7. Your original clipboard content is preserved and restored.
 
 ---
@@ -217,7 +216,7 @@ go test ./...
 | GhostType doesn't respond to hotkeys | Make sure the target window (Firestorm) is focused and the window title matches `target_window` in `config.json`. |
 | API errors | Check your API key in `config.json`. Check `ghosttype.log` for details. Verify your provider account has credits. |
 | Slow corrections | Response time depends on provider and network. Try a faster model or switch to a local Ollama instance. |
-| Hotkey conflicts | If F3/F5 conflict with other apps, change the hotkeys in `config.json`. |
+| Hotkey conflicts | If F6/F7/F8 conflict with other apps, change the hotkeys in `config.json`. |
 
 ---
 


### PR DESCRIPTION
## Summary
This PR updates the hotkey assignments and simplifies the text replacement workflow in GhostType. The changes move from F3/F4/F5-based hotkeys to F6/F7/F8, eliminate the explicit "apply" action, and implement auto-replacement with native undo support.

## Key Changes

- **Hotkey reassignment**: 
  - Correction mode: F3 → F6
  - Translation mode: F4 → F7
  - Rewrite mode: Ctrl+F3 → F8
  - Template cycling: Ctrl+F4 → Ctrl+F8
  - Removed F5 (apply) hotkey entirely

- **Simplified workflow**:
  - Text now auto-replaces after LLM processing (no explicit accept step)
  - Users press Escape to cancel in-progress operations
  - Users press Ctrl+Z (native undo) to revert replacements if needed

- **Rationale documentation**:
  - Added "Default Hotkey Rationale" section explaining why F6/F7/F8 were chosen
  - Documented why other function keys were avoided (F1-F5, F10-F12 have standard bindings)
  - Emphasized that all hotkeys remain fully configurable in config.json

- **Updated configuration**:
  - Removed "apply" key from hotkeys configuration
  - Updated all example configs and documentation to reflect new hotkey mappings

## Implementation Details

The workflow now follows a simpler pattern:
1. User presses hotkey (F6/F7/F8) to trigger operation
2. Service processes text via LLM
3. Result automatically replaces original text in chat input
4. User can press Escape to cancel or Ctrl+Z to undo

This eliminates the need for an explicit acceptance step and leverages native application undo functionality, reducing cognitive load and making the tool feel more integrated with standard text editing workflows.

https://claude.ai/code/session_01PvPicBUtwGRRKBHCtmwscf