### PR TITLE
Add Ctrl+F7/F8 toggle hotkeys with cursor notifications

### DIFF
--- a/GhostType requierement.MD
+++ b/GhostType requierement.MD
@@ -52,11 +52,11 @@ Detects the language of the typed text (French or English). Fixes all spelling, 
 
 Mode 2 — Translate (F7)
 
-Translates the typed text to the configured target language. Auto-detects source language. User configures default target language in config.json. Useful for switching between French and English chat in Firestorm.
+Translates the typed text to the currently selected target language. Auto-detects source language. User configures default target language in config.json and can toggle through the languages list at any time with Ctrl+F7 — a brief floating label near the cursor confirms the new target (e.g., "To French"). Useful for switching between French and English chat in Firestorm.
 
 Mode 3 — Rewrite (F8)
 
-Sends the typed text to the LLM with a creative prompt template. User cycles through available templates with Ctrl+F8. Templates are fully configurable in config.json. Examples: funny reply, formal tone, sarcastic, flirty, poetic, ELI5, pirate speak, or any custom prompt the user defines.
+Sends the typed text to the LLM with a creative prompt template. User toggles through available templates with Ctrl+F8 — a brief floating label near the cursor shows the newly selected template name (e.g., "Funny", "Professional"). Templates are fully configurable in config.json. Examples: funny reply, formal tone, sarcastic, flirty, poetic, ELI5, pirate speak, or any custom prompt the user defines.
 
 
 
@@ -68,11 +68,13 @@ Full Hotkey Map
 
 F6: Capture text and send for correction (Mode 1)
 
-F7: Capture text and send for translation (Mode 2)
+Ctrl+F7: Toggle translation target language. Cycles through the languages list in config.json. Shows a brief cursor-near notification displaying the new target language name (e.g., "To French", "To English"). Does not perform any text action, just switches the target.
+
+F7: Capture text and send for translation to the currently selected target language (Mode 2)
+
+Ctrl+F8: Toggle rewrite template. Cycles through the rewrite_templates list in config.json. Shows a brief cursor-near notification displaying the template name (e.g., "Funny", "Professional", "Casual"). Does not perform any text action, just switches the active template.
 
 F8: Capture text and send for rewrite using active template (Mode 3)
-
-Ctrl+F8: Cycle through rewrite templates (overlay shows current template name)
 
 Escape: Cancel in-progress operation
 
@@ -85,6 +87,8 @@ Detailed Flow
 
 
 User types text in target application chat input field.
+
+Optionally, user presses Ctrl+F7 to toggle the translation target language or Ctrl+F8 to toggle the rewrite template. A brief floating label appears near the cursor confirming the selection (e.g., "To French" or "Funny").
 
 User presses the hotkey for the desired mode (F6, F7, or F8).
 
@@ -135,7 +139,9 @@ Service starts on boot or manually, reads config.json.
 
 Service runs in background, monitoring for hotkey presses when target window is active.
 
-On hotkey press, service captures text, determines mode, sends to LLM API.
+User can press Ctrl+F7 to toggle the translation target language or Ctrl+F8 to toggle the rewrite template. A brief floating label appears near the cursor confirming the selection.
+
+On action hotkey press (F6, F7, F8), service captures text, determines mode, sends to LLM API.
 
 LLM returns result, service displays in overlay.
 
@@ -151,7 +157,9 @@ Window Detection Module — Detects if the target application is the active/focu
 
 Text Capture Module — Grabs current chat input text via clipboard. Selects all text in the active input field (Ctrl+A / Cmd+A), copies to clipboard, reads clipboard content. Saves and restores original clipboard content to avoid disrupting user workflow.
 
-Mode Router — Determines which prompt to use based on the hotkey pressed. Routes to correction, translation, or rewrite prompt. Manages the active rewrite template selection.
+Cursor Notification Module — Displays a tiny, semi-transparent floating label near the mouse cursor position when the user presses Ctrl+F7 or Ctrl+F8. The label shows the name of the newly selected language (e.g., "To French") or template (e.g., "Funny"). It appears for 2 seconds and fades out. On Windows this is implemented as a small borderless, always-on-top, transparent window positioned near the cursor using GetCursorPos. This is NOT a full overlay, just a minimal floating label.
+
+Mode Router — Determines which prompt to use based on the hotkey pressed. Routes to correction, translation, or rewrite prompt. Manages the active rewrite template selection and active translation target language.
 
 LLM API Client Module — Sends requests to configured provider. Supports: OpenAI, Anthropic (Claude), Google Gemini, xAI (Grok), Ollama (local). Handles authentication, request formatting, response parsing per provider. Implements timeout and retry logic. Provider-agnostic interface so adding new providers is straightforward.
 
@@ -177,7 +185,15 @@ Configuration File (config.json)
 
 &nbsp; "api\_endpoint": "",
 
-&nbsp; "languages": \["fr", "en"],
+&nbsp; "languages": \["en", "fr"],
+
+&nbsp; "language\_names": {
+
+&nbsp;   "en": "English",
+
+&nbsp;   "fr": "French"
+
+&nbsp; },
 
 &nbsp; "default\_translate\_target": "en",
 
@@ -186,6 +202,8 @@ Configuration File (config.json)
 &nbsp;   "correct": "F6",
 
 &nbsp;   "translate": "F7",
+
+&nbsp;   "toggle\_language": "Ctrl+F7",
 
 &nbsp;   "rewrite": "F8",
 
@@ -351,6 +369,8 @@ v0.2 — Translation and Overlay
 
 Add translation mode (F7)
 
+Ctrl+F7 toggle translation target language with cursor notification
+
 Transparent overlay window replaces the app window for showing results
 
 Overlay positioned near target application chat input
@@ -368,6 +388,8 @@ v0.3 — Rewrite Mode and Polish
 
 
 Add rewrite mode (F8) with configurable templates
+
+Ctrl+F8 toggle rewrite template with cursor notification
 
 Template cycling (Ctrl+F8)
 
@@ -574,6 +596,12 @@ ghosttype/
 &nbsp; clipboard/
 
 &nbsp;   clipboard.go           — Clipboard read/write with preservation
+
+&nbsp; cursor/
+
+&nbsp;   cursor.go              — Interface for cursor position and floating label
+
+&nbsp;   cursor\_windows.go      — Windows implementation using GetCursorPos and borderless window
 
 &nbsp; mode/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 GhostType is a lightweight background service that hooks into your chat application (primarily Firestorm Second Life viewer) and provides real-time spelling correction, language translation, and creative text rewriting — powered by your choice of LLM provider.
 
-Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, corrected too. Need to translate? **F7**. Want a funny reply? **F8**. Undo with **Ctrl+Z** or cancel with **Escape**. That simple.
+Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, corrected too. Need to translate? **F7**. Want to change the target language? **Ctrl+F7** — a tiny floating label near your cursor shows "To French" or "To English". Want a funny reply? **F8**. Want to switch rewrite style? **Ctrl+F8** — a floating label shows "Funny", "Professional", etc. Undo with **Ctrl+Z** or cancel with **Escape**. That simple.
 
 ---
 
@@ -34,7 +34,7 @@ Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, cor
 - **Translate** — Instantly translates between French and English (or any configured language pair)
 - **Rewrite** — Rewrites your text using customizable prompt templates (funny, formal, sarcastic, flirty, poetic, and more)
 - **Multi-Provider** — Works with Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, or local Ollama models
-- **Hotkey Driven** — F6 to correct, F7 to translate, F8 to rewrite, Ctrl+F8 to cycle templates, Escape to cancel
+- **Hotkey Driven** — F6 to correct, F7 to translate, F8 to rewrite, Ctrl+F7 to toggle translation language, Ctrl+F8 to cycle rewrite templates, Escape to cancel
 - **Configurable** — JSON config file for API keys, providers, hotkeys, prompts, overlay settings, and custom rewrite templates
 - **Lightweight** — Single binary, runs in the background, under 50 MB memory, near-zero CPU at idle
 - **Cross-Platform** — Windows first, Linux and macOS coming in future releases
@@ -73,10 +73,11 @@ GhostType starts minimized in your system tray. Open Firestorm, type something i
 
 | Hotkey | Action |
 |--------|--------|
-| **F6** | Correct spelling and grammar |
-| **F7** | Translate to target language |
-| **F8** | Rewrite using active template |
-| **Ctrl+F8** | Cycle through rewrite templates |
+| **F6** | Correct spelling, grammar, and syntax |
+| **Ctrl+F7** | Toggle translation target language (shows cursor notification) |
+| **F7** | Translate to selected target language |
+| **Ctrl+F8** | Toggle rewrite template (shows cursor notification) |
+| **F8** | Rewrite using selected template |
 | **Escape** | Cancel in-progress operation |
 | **Ctrl+Z** | Undo replacement (native) |
 
@@ -94,11 +95,16 @@ GhostType is configured entirely through `config.json`. Here is a full example:
   "api_key": "sk-ant-xxxxx",
   "model": "claude-sonnet-4-5-20250929",
   "api_endpoint": "",
-  "languages": ["fr", "en"],
+  "languages": ["en", "fr"],
+  "language_names": {
+    "en": "English",
+    "fr": "French"
+  },
   "default_translate_target": "en",
   "hotkeys": {
     "correct": "F6",
     "translate": "F7",
+    "toggle_language": "Ctrl+F7",
     "rewrite": "F8",
     "cycle_template": "Ctrl+F8",
     "cancel": "Escape"
@@ -157,7 +163,7 @@ You can add your own rewrite styles by editing the `rewrite_templates` array in 
 }
 ```
 
-Cycle through templates in real-time with **Ctrl+F8**. The overlay shows which template is currently active.
+Cycle through templates in real-time with **Ctrl+F8**. A brief floating label appears near your cursor showing the newly selected template name (e.g., "Funny", "Professional"). Similarly, toggle the translation target language with **Ctrl+F7** — a label appears showing "To French", "To English", etc.
 
 ---
 
@@ -189,11 +195,12 @@ go test ./...
 
 1. GhostType runs in the background and watches for hotkey presses.
 2. It only activates when the configured target window (default: Firestorm) is focused.
-3. When you press a hotkey, it selects all text in the active chat input, copies it to clipboard, and reads it.
-4. The text is sent to your configured LLM provider with the appropriate prompt.
-5. The corrected/translated/rewritten result appears in an overlay near the chat input.
-6. The result auto-replaces your text. Press **Escape** to cancel, or **Ctrl+Z** to undo.
-7. Your original clipboard content is preserved and restored.
+3. Before translating, you can press **Ctrl+F7** to toggle the translation target language. A brief floating label appears near your cursor showing the new target (e.g., "To French"). Before rewriting, you can press **Ctrl+F8** to toggle the rewrite template. A floating label appears showing the template name (e.g., "Funny", "Professional").
+4. When you press an action hotkey (**F6**, **F7**, or **F8**), GhostType selects all text in the active chat input, copies it to clipboard, and reads it.
+5. The text is sent to your configured LLM provider with the appropriate prompt.
+6. The corrected/translated/rewritten result appears in an overlay near the chat input.
+7. The result auto-replaces your text. Press **Escape** to cancel, or **Ctrl+Z** to undo.
+8. Your original clipboard content is preserved and restored.
 
 ---
 
@@ -202,8 +209,8 @@ go test ./...
 | Version | Focus | Highlights |
 |---------|-------|------------|
 | **v0.1** | MVP (current) | Windows desktop app. Correction mode. Anthropic and OpenAI support. |
-| **v0.2** | Translation & Overlay | Translation mode. Transparent overlay. Ollama support. Linux. |
-| **v0.3** | Rewrite Mode | Creative rewrite templates. Config hot-reload. macOS. |
+| **v0.2** | Translation & Overlay | Translation mode. Ctrl+F7 toggle language with cursor notification. Transparent overlay. Ollama support. Linux. |
+| **v0.3** | Rewrite Mode | Creative rewrite templates. Ctrl+F8 toggle template with cursor notification. Config hot-reload. macOS. |
 | **v0.4** | More Providers | Gemini and xAI support. GUI config panel. Additional languages. |
 | **v0.5** | Power Features | Real-time Grammarly-style correction. Usage stats. Custom plugins. |
 


### PR DESCRIPTION
## Summary
This PR adds toggle hotkeys for translation language and rewrite templates with visual cursor notifications, improving the user experience by allowing quick switching between modes without performing text actions.

## Key Changes

- **New Toggle Hotkeys**: Added `Ctrl+F7` to toggle translation target language and `Ctrl+F8` to toggle rewrite template, separate from the action hotkeys (F7 and F8)
- **Cursor Notification Module**: Introduced new cursor notification system that displays a brief floating label near the mouse cursor when toggling languages or templates (e.g., "To French", "Funny")
- **Language Names Configuration**: Added `language_names` mapping in config.json to display human-readable language names in notifications instead of language codes
- **Mode Router Enhancement**: Updated to manage both active rewrite template selection and active translation target language
- **Hotkey Map Reorganization**: Restructured hotkey documentation to clearly distinguish between toggle hotkeys (Ctrl+F7, Ctrl+F8) and action hotkeys (F6, F7, F8)
- **Detailed Flow Updates**: Added step explaining optional toggle actions before pressing action hotkeys
- **Project Structure**: Added new `cursor/` module with platform-specific implementations (Windows using GetCursorPos and borderless window)

## Implementation Details

- Cursor notifications are minimal floating labels (not full overlays) that appear for ~2 seconds and fade out
- Windows implementation uses borderless, always-on-top, transparent windows positioned near cursor
- Toggle actions do not perform text operations—they only switch the active configuration
- Original clipboard content preservation is maintained throughout all operations
- Configuration supports multiple languages with customizable names for UI display

https://claude.ai/code/session_013TgNT1AkkvPgbuK1x4JzyU