### PR TITLE
Fix POC: wire runLive() dispatch so F6 workflow runs on Windows

### DIFF
--- a/cmd/poc/main.go
+++ b/cmd/poc/main.go
@@ -21,9 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 )
 
 var testMode = flag.Bool("test", false, "Run in test mode with simulated clipboard (no Windows APIs needed)")
@@ -42,19 +40,7 @@ func main() {
 		return
 	}
 
-	// On non-Windows, just show instructions
-	fmt.Println("This POC requires Windows for live hotkey support.")
-	fmt.Println("Use '-test' flag to run the simulated demo:")
-	fmt.Println("  go run ./cmd/poc -test")
-	fmt.Println()
-	fmt.Println("On Windows, build and run:")
-	fmt.Println("  go build -o ghosttype-poc.exe ./cmd/poc")
-	fmt.Println("  ghosttype-poc.exe")
-	fmt.Println()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
+	runLive()
 }
 
 // correctText is the simple test replacement — no LLM needed.

--- a/cmd/poc/workflow_other.go
+++ b/cmd/poc/workflow_other.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func runLive() {
+	fmt.Println("This POC requires Windows for live hotkey support.")
+	fmt.Println("Use '-test' flag to run the simulated demo:")
+	fmt.Println("  go run ./cmd/poc -test")
+	fmt.Println()
+	fmt.Println("On Windows, build and run:")
+	fmt.Println("  go build -o ghosttype-poc.exe ./cmd/poc")
+	fmt.Println("  ghosttype-poc.exe")
+	fmt.Println()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+}

--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -24,9 +24,8 @@ func winBeep(freq, durationMs uint32) {
 	procBeep.Call(uintptr(freq), uintptr(durationMs))
 }
 
-func init() {
-	// On Windows, override main to use live hotkey mode
-	// This is called before main() when built on Windows
+func runLive() {
+	RunWindowsLive()
 }
 
 // RunWindowsLive registers F6 as a global hotkey and runs the clipboard


### PR DESCRIPTION
## Summary
- **Root cause**: `RunWindowsLive()` was defined in `workflow_windows.go` but never called — the `init()` was empty, so the POC just printed instructions and waited even on Windows
- Added `runLive()` build-tag dispatch: Windows calls `RunWindowsLive()`, other platforms show fallback instructions
- Created `workflow_other.go` (`//go:build !windows`) for the non-Windows fallback
- Cleaned up unused imports in `main.go`

## Test plan
- [ ] On Windows: `go build -o ghosttype-poc.exe ./cmd/poc && .\ghosttype-poc.exe` — F6 should trigger clipboard workflow, Escape should exit cleanly
- [ ] On any OS: `go run ./cmd/poc -test` — simulated test mode still works
- [ ] On Linux/macOS: `go run ./cmd/poc` — shows fallback instructions

Related to #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)