### PR TITLE
Shift hotkeys F6→F7→F8→F9 + add v0.1.0 versioning

### DIFF
--- a/cmd/poc/main.go
+++ b/cmd/poc/main.go
@@ -1,12 +1,12 @@
-// cmd/poc/main.go — Proof of Concept: F6 clipboard correction workflow
+// cmd/poc/main.go — Proof of Concept: F7 clipboard correction workflow
 //
-// This POC demonstrates the F6 correction pipeline WITHOUT any LLM calls.
+// This POC demonstrates the F7 correction pipeline WITHOUT any LLM calls.
 // Instead of calling an LLM, it uses a simple test message to prove
 // the clipboard workflow works end-to-end.
 //
 // The workflow:
-//   1. F6 hotkey registered as global hotkey (Windows)
-//   2. On F6: Ctrl+A → Ctrl+C → read clipboard → replace with test message → Ctrl+A → Ctrl+V
+//   1. F7 hotkey registered as global hotkey (Windows)
+//   2. On F7: Ctrl+A → Ctrl+C → read clipboard → replace with test message → Ctrl+A → Ctrl+V
 //   3. Original clipboard content is preserved and restored
 //
 // Build for Windows:
@@ -30,7 +30,7 @@ func main() {
 	flag.Parse()
 
 	fmt.Println("==============================================")
-	fmt.Println("  GhostType POC — F6 Clipboard Workflow")
+	fmt.Println("  GhostType POC v0.1.0 — F7 Clipboard Workflow")
 	fmt.Println("  (No LLM — uses test message)")
 	fmt.Println("==============================================")
 	fmt.Println()
@@ -56,7 +56,7 @@ func beep() {
 	fmt.Print("\a") // ASCII BEL character — terminal beep
 }
 
-// runTestMode simulates the full F6 clipboard workflow without any
+// runTestMode simulates the full F7 clipboard workflow without any
 // platform-specific APIs. Works on any OS.
 func runTestMode() {
 	fmt.Println("Running in TEST MODE (simulated clipboard)")

--- a/cmd/poc/poc_test.go
+++ b/cmd/poc/poc_test.go
@@ -26,7 +26,7 @@ func TestCorrectText(t *testing.T) {
 	}
 }
 
-// TestPOC_ClipboardWorkflow simulates the full F6 workflow
+// TestPOC_ClipboardWorkflow simulates the full F7 workflow
 // using a mock clipboard.
 func TestPOC_ClipboardWorkflow(t *testing.T) {
 	var store string = "user's important data"
@@ -81,7 +81,7 @@ func TestPOC_ClipboardWorkflow(t *testing.T) {
 		t.Errorf("Clipboard not restored! Got %q", restored)
 	}
 
-	t.Log("PASS: Full F6 workflow verified")
+	t.Log("PASS: Full F7 workflow verified")
 	t.Logf("  Captured: %q → Corrected: %q → Clipboard restored: %q", captured, corrected, restored)
 }
 

--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -28,16 +28,16 @@ func runLive() {
 	RunWindowsLive()
 }
 
-// RunWindowsLive registers F6 as a global hotkey and runs the clipboard
+// RunWindowsLive registers F7 as a global hotkey and runs the clipboard
 // workflow with a simple test message (no LLM).
 func RunWindowsLive() {
 	cb := clipboard.NewWindowsClipboard()
 	kb := keyboard.NewWindowsSimulator()
 	hk := hotkey.NewWindowsManager()
 
-	err := hk.Register("correct", "F6", func() {
-		fmt.Println("[F6] Correction triggered!")
-		winBeep(800, 100) // Short beep to confirm F6 press
+	err := hk.Register("correct", "F7", func() {
+		fmt.Println("[F7] Correction triggered!")
+		winBeep(800, 100) // Short beep to confirm F7 press
 
 		// Step 1: Save original clipboard
 		if err := cb.Save(); err != nil {
@@ -93,7 +93,7 @@ func RunWindowsLive() {
 		fmt.Println("[OK] Done!")
 	})
 	if err != nil {
-		fmt.Printf("Failed to register F6: %v\n", err)
+		fmt.Printf("Failed to register F7: %v\n", err)
 		return
 	}
 
@@ -108,7 +108,7 @@ func RunWindowsLive() {
 		return
 	}
 
-	fmt.Println("F6 registered! Press F6 in any text field to test.")
+	fmt.Println("F7 registered! Press F7 in any text field to test.")
 	fmt.Println("Text will be uppercased with [CORRECTED] prefix.")
 	fmt.Println("Press Escape to exit.")
 

--- a/config/config.go
+++ b/config/config.go
@@ -76,11 +76,11 @@ func DefaultConfig() Config {
 		},
 		DefaultTranslateTarget: "en",
 		Hotkeys: Hotkeys{
-			Correct:        "F6",
-			Translate:      "F7",
-			ToggleLanguage: "Ctrl+F7",
-			Rewrite:        "F8",
-			CycleTemplate:  "Ctrl+F8",
+			Correct:        "F7",
+			Translate:      "F8",
+			ToggleLanguage: "Ctrl+F8",
+			Rewrite:        "F9",
+			CycleTemplate:  "Ctrl+F9",
 			Cancel:         "Escape",
 		},
 		TargetWindow: "Firestorm",
@@ -172,7 +172,7 @@ func applyDefaults(cfg *Config) {
 		cfg.TargetWindow = "Firestorm"
 	}
 	if cfg.Hotkeys.Correct == "" {
-		cfg.Hotkeys.Correct = "F6"
+		cfg.Hotkeys.Correct = "F7"
 	}
 	if cfg.Hotkeys.Cancel == "" {
 		cfg.Hotkeys.Cancel = "Escape"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,14 +22,14 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.TimeoutMs != 5000 {
 		t.Errorf("expected default timeout_ms 5000, got %d", cfg.TimeoutMs)
 	}
-	if cfg.Hotkeys.Correct != "F6" {
-		t.Errorf("expected default correct hotkey 'F6', got '%s'", cfg.Hotkeys.Correct)
+	if cfg.Hotkeys.Correct != "F7" {
+		t.Errorf("expected default correct hotkey 'F7', got '%s'", cfg.Hotkeys.Correct)
 	}
-	if cfg.Hotkeys.Translate != "F7" {
-		t.Errorf("expected default translate hotkey 'F7', got '%s'", cfg.Hotkeys.Translate)
+	if cfg.Hotkeys.Translate != "F8" {
+		t.Errorf("expected default translate hotkey 'F8', got '%s'", cfg.Hotkeys.Translate)
 	}
-	if cfg.Hotkeys.Rewrite != "F8" {
-		t.Errorf("expected default rewrite hotkey 'F8', got '%s'", cfg.Hotkeys.Rewrite)
+	if cfg.Hotkeys.Rewrite != "F9" {
+		t.Errorf("expected default rewrite hotkey 'F9', got '%s'", cfg.Hotkeys.Rewrite)
 	}
 	if cfg.TargetWindow != "Firestorm" {
 		t.Errorf("expected default target_window 'Firestorm', got '%s'", cfg.TargetWindow)

--- a/ghosttype_test.go
+++ b/ghosttype_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/chrixbedardcad/GhostType/mode"
 )
 
-// TestFullCorrectionPipeline tests the complete F6 correction workflow
+// TestFullCorrectionPipeline tests the complete F7 correction workflow
 // with a mock LLM server.
 func TestFullCorrectionPipeline(t *testing.T) {
 	// 1. Set up mock LLM server
@@ -67,7 +67,7 @@ func TestFullCorrectionPipeline(t *testing.T) {
 	// 4. Create mode router
 	router := mode.NewRouter(cfg, client)
 
-	// 5. Simulate F6 correction
+	// 5. Simulate F7 correction
 	inputText := "Helo, how are yu tday?"
 	result, err := router.Process(context.Background(), mode.ModeCorrect, inputText)
 	if err != nil {
@@ -82,7 +82,7 @@ func TestFullCorrectionPipeline(t *testing.T) {
 	t.Logf("Output: %s", result)
 }
 
-// TestFullTranslationPipeline tests the F7 translation workflow.
+// TestFullTranslationPipeline tests the F8 translation workflow.
 func TestFullTranslationPipeline(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]interface{}{
@@ -137,7 +137,7 @@ func TestFullTranslationPipeline(t *testing.T) {
 	t.Logf("Output: %s", result)
 }
 
-// TestFullRewritePipeline tests the F8 rewrite workflow.
+// TestFullRewritePipeline tests the F9 rewrite workflow.
 func TestFullRewritePipeline(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]interface{}{

--- a/hotkey/hotkey_windows.go
+++ b/hotkey/hotkey_windows.go
@@ -24,9 +24,9 @@ const (
 	modShift = 0x0004
 
 	vkEscape = 0x1B
-	vkF6     = 0x75
 	vkF7     = 0x76
 	vkF8     = 0x77
+	vkF9     = 0x78
 )
 
 const wmHotkey = 0x0312
@@ -63,7 +63,7 @@ func NewWindowsManager() *WindowsManager {
 	}
 }
 
-// parseKey converts a key string like "F6" or "Ctrl+F7" into modifier and vk code.
+// parseKey converts a key string like "F7" or "Ctrl+F8" into modifier and vk code.
 func parseKey(key string) (uint32, uint32, error) {
 	var mod uint32
 	parts := strings.Split(key, "+")
@@ -88,9 +88,9 @@ func parseKey(key string) (uint32, uint32, error) {
 }
 
 var keyMap = map[string]uint32{
-	"f6":     vkF6,
 	"f7":     vkF7,
 	"f8":     vkF8,
+	"f9":     vkF9,
 	"escape": vkEscape,
 }
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 func main() {
-	fmt.Println("GhostType - AI-powered multilingual auto-correction")
+	fmt.Printf("GhostType v%s - AI-powered multilingual auto-correction\n", Version)
 	fmt.Println("====================================================")
 
 	// Determine config path (same directory as executable)

--- a/mode/router.go
+++ b/mode/router.go
@@ -13,9 +13,9 @@ import (
 type Mode int
 
 const (
-	ModeCorrect   Mode = iota // F6 - spelling/grammar correction
-	ModeTranslate             // F7 - translation
-	ModeRewrite               // F8 - creative rewrite
+	ModeCorrect   Mode = iota // F7 - spelling/grammar correction
+	ModeTranslate             // F8 - translation
+	ModeRewrite               // F9 - creative rewrite
 )
 
 func (m Mode) String() string {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const Version = "0.1.0"


### PR DESCRIPTION
## Summary
- **Fix POC build-tag dispatch**: Wire `runLive()` so `RunWindowsLive()` is actually called on Windows, with a no-op stub for other platforms
- **Shift hotkeys up by one**: F6 conflicts with the Windows search bar, so all hotkeys now use F7/F8/F9 instead of F6/F7/F8
- **Add v0.1.0 versioning**: New `version.go` constant displayed in both main and POC startup banners

### New Hotkey Layout
| Key | Function |
|---|---|
| F7 | Correct |
| F8 | Translate |
| Ctrl+F8 | Toggle language |
| F9 | Rewrite |
| Ctrl+F9 | Cycle template |
| Escape | Cancel |

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` — all 6 test packages pass
- [ ] On Windows: build and run POC (`go build -o ghosttype-poc.exe ./cmd/poc`), press F7 to trigger correction, Escape to exit
- [ ] Verify startup banner shows `GhostType v0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)