### PR TITLE
Add file-based debug logging to POC

### DIFF
--- a/cmd/poc/main.go
+++ b/cmd/poc/main.go
@@ -20,20 +20,35 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strings"
 )
 
-var testMode = flag.Bool("test", false, "Run in test mode with simulated clipboard (no Windows APIs needed)")
+var (
+	testMode = flag.Bool("test", false, "Run in test mode with simulated clipboard (no Windows APIs needed)")
+	logFile  = flag.String("log", "ghosttype-poc.log", "Path to debug log file")
+)
 
 func main() {
 	flag.Parse()
 
-	fmt.Println("==============================================")
-	fmt.Println("  GhostType POC v0.1.0 — F7 Clipboard Workflow")
-	fmt.Println("  (No LLM — uses test message)")
-	fmt.Println("==============================================")
-	fmt.Println()
+	// Set up logging to both stdout and log file
+	f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open log file %s: %v\n", *logFile, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	log.SetOutput(io.MultiWriter(os.Stdout, f))
+	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
+
+	log.Println("==============================================")
+	log.Println("  GhostType POC v0.1.0 — F7 Clipboard Workflow")
+	log.Println("  (No LLM — uses test message)")
+	log.Printf("  Log file: %s", *logFile)
+	log.Println("==============================================")
 
 	if *testMode {
 		runTestMode()

--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"syscall"
 	"time"
@@ -31,86 +31,122 @@ func runLive() {
 // RunWindowsLive registers F7 as a global hotkey and runs the clipboard
 // workflow with a simple test message (no LLM).
 func RunWindowsLive() {
+	log.Println("[INIT] Creating clipboard, keyboard, hotkey managers")
 	cb := clipboard.NewWindowsClipboard()
 	kb := keyboard.NewWindowsSimulator()
 	hk := hotkey.NewWindowsManager()
 
+	log.Println("[INIT] Registering F7 hotkey...")
 	err := hk.Register("correct", "F7", func() {
-		fmt.Println("[F7] Correction triggered!")
+		log.Println("[F7] ---- Correction triggered! ----")
 		winBeep(800, 100) // Short beep to confirm F7 press
 
 		// Step 1: Save original clipboard
+		log.Println("[STEP 1] Saving original clipboard...")
 		if err := cb.Save(); err != nil {
-			fmt.Printf("[ERROR] Failed to save clipboard: %v\n", err)
+			log.Printf("[ERROR] Failed to save clipboard: %v", err)
 			return
 		}
+		log.Println("[STEP 1] Clipboard saved OK")
 
 		// Step 2: Select all text in active window
-		kb.SelectAll()
+		log.Println("[STEP 2] Sending Ctrl+A (SelectAll)...")
+		if err := kb.SelectAll(); err != nil {
+			log.Printf("[ERROR] SelectAll failed: %v", err)
+			cb.Restore()
+			return
+		}
+		log.Println("[STEP 2] SelectAll sent, sleeping 50ms")
 		time.Sleep(50 * time.Millisecond)
 
 		// Step 3: Copy selected text
-		kb.Copy()
+		log.Println("[STEP 3] Sending Ctrl+C (Copy)...")
+		if err := kb.Copy(); err != nil {
+			log.Printf("[ERROR] Copy failed: %v", err)
+			cb.Restore()
+			return
+		}
+		log.Println("[STEP 3] Copy sent, sleeping 100ms")
 		time.Sleep(100 * time.Millisecond)
 
 		// Step 4: Read clipboard to get input text
+		log.Println("[STEP 4] Reading clipboard...")
 		text, err := cb.Read()
 		if err != nil {
-			fmt.Printf("[ERROR] Failed to read clipboard: %v\n", err)
+			log.Printf("[ERROR] Failed to read clipboard: %v", err)
 			cb.Restore()
 			return
 		}
 
 		if text == "" {
-			fmt.Println("[WARN] Nothing to correct (empty text)")
+			log.Println("[WARN] Nothing to correct (empty text)")
 			cb.Restore()
 			return
 		}
 
-		fmt.Printf("[INPUT]  %q\n", text)
+		log.Printf("[STEP 4] Clipboard text (%d chars): %q", len(text), text)
 
 		// Step 5: Apply simple correction (no LLM)
 		corrected := correctText(text)
-		fmt.Printf("[OUTPUT] %q\n", corrected)
+		log.Printf("[STEP 5] Corrected text: %q", corrected)
 
 		// Step 6: Write result to clipboard
+		log.Println("[STEP 6] Writing corrected text to clipboard...")
 		if err := cb.Write(corrected); err != nil {
-			fmt.Printf("[ERROR] Failed to write clipboard: %v\n", err)
+			log.Printf("[ERROR] Failed to write clipboard: %v", err)
 			cb.Restore()
 			return
 		}
+		log.Println("[STEP 6] Clipboard written OK")
 
 		// Step 7: Select all and paste
-		kb.SelectAll()
+		log.Println("[STEP 7] Sending Ctrl+A (SelectAll)...")
+		if err := kb.SelectAll(); err != nil {
+			log.Printf("[ERROR] SelectAll (paste prep) failed: %v", err)
+			cb.Restore()
+			return
+		}
 		time.Sleep(50 * time.Millisecond)
-		kb.Paste()
+
+		log.Println("[STEP 7] Sending Ctrl+V (Paste)...")
+		if err := kb.Paste(); err != nil {
+			log.Printf("[ERROR] Paste failed: %v", err)
+			cb.Restore()
+			return
+		}
+		log.Println("[STEP 7] Paste sent, sleeping 50ms")
 		time.Sleep(50 * time.Millisecond)
 
 		// Step 8: Restore original clipboard
+		log.Println("[STEP 8] Restoring original clipboard...")
 		cb.Restore()
+		log.Println("[STEP 8] Clipboard restored")
 
 		winBeep(1200, 150) // Higher beep to confirm correction complete
-		fmt.Println("[OK] Done!")
+		log.Println("[OK] ---- Correction complete! ----")
 	})
 	if err != nil {
-		fmt.Printf("Failed to register F7: %v\n", err)
+		log.Printf("[FATAL] Failed to register F7: %v", err)
 		return
 	}
+	log.Println("[INIT] F7 hotkey registered OK")
 
+	log.Println("[INIT] Registering Escape hotkey...")
 	err = hk.Register("quit", "Escape", func() {
-		fmt.Println("Escape pressed — exiting cleanly.")
+		log.Println("Escape pressed — exiting cleanly.")
 		hk.Unregister("correct")
 		hk.Unregister("quit")
 		os.Exit(0)
 	})
 	if err != nil {
-		fmt.Printf("Failed to register Escape: %v\n", err)
+		log.Printf("[FATAL] Failed to register Escape: %v", err)
 		return
 	}
+	log.Println("[INIT] Escape hotkey registered OK")
 
-	fmt.Println("F7 registered! Press F7 in any text field to test.")
-	fmt.Println("Text will be uppercased with [CORRECTED] prefix.")
-	fmt.Println("Press Escape to exit.")
+	log.Println("F7 registered! Press F7 in any text field to test.")
+	log.Println("Text will be uppercased with [CORRECTED] prefix.")
+	log.Println("Press Escape to exit.")
 
 	hk.Listen()
 }

--- a/keyboard/keyboard_windows.go
+++ b/keyboard/keyboard_windows.go
@@ -3,6 +3,7 @@
 package keyboard
 
 import (
+	"fmt"
 	"syscall"
 	"time"
 	"unsafe"
@@ -47,7 +48,7 @@ func NewWindowsSimulator() *WindowsSimulator {
 	return &WindowsSimulator{}
 }
 
-func sendKey(vk uint16, down bool) {
+func sendKey(vk uint16, down bool) error {
 	var flags uint32
 	if !down {
 		flags = keyEventUp
@@ -55,32 +56,46 @@ func sendKey(vk uint16, down bool) {
 	inp := input{
 		inputType: inputKeyboard,
 		ki: keybdInput{
-			wVk:   vk,
+			wVk:     vk,
 			dwFlags: flags,
 		},
 	}
-	procSendInput.Call(1, uintptr(unsafe.Pointer(&inp)), unsafe.Sizeof(inp))
+	ret, _, _ := procSendInput.Call(1, uintptr(unsafe.Pointer(&inp)), unsafe.Sizeof(inp))
+	if ret == 0 {
+		action := "keydown"
+		if !down {
+			action = "keyup"
+		}
+		return fmt.Errorf("SendInput failed for vk=0x%02X %s", vk, action)
+	}
+	return nil
 }
 
-func sendKeyCombo(modifier, key uint16) {
-	sendKey(modifier, true)
-	sendKey(key, true)
+func sendKeyCombo(modifier, key uint16) error {
+	if err := sendKey(modifier, true); err != nil {
+		return err
+	}
+	if err := sendKey(key, true); err != nil {
+		return err
+	}
 	time.Sleep(10 * time.Millisecond)
-	sendKey(key, false)
-	sendKey(modifier, false)
+	if err := sendKey(key, false); err != nil {
+		return err
+	}
+	if err := sendKey(modifier, false); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (s *WindowsSimulator) SelectAll() error {
-	sendKeyCombo(vkControl, vkA)
-	return nil
+	return sendKeyCombo(vkControl, vkA)
 }
 
 func (s *WindowsSimulator) Copy() error {
-	sendKeyCombo(vkControl, vkC)
-	return nil
+	return sendKeyCombo(vkControl, vkC)
 }
 
 func (s *WindowsSimulator) Paste() error {
-	sendKeyCombo(vkControl, vkV)
-	return nil
+	return sendKeyCombo(vkControl, vkV)
 }


### PR DESCRIPTION
## Summary
- Add `-log` flag (default: `ghosttype-poc.log`) that writes timestamped logs to both stdout and a file via `io.MultiWriter`
- Replace all `fmt.Println`/`Printf` with `log.Println`/`Printf` in `workflow_windows.go`, adding `[STEP N]` labels at every step boundary
- Make `keyboard/keyboard_windows.go` return real errors from `SendInput` (checks return value == 0) and propagate through `sendKeyCombo`/`SelectAll`/`Copy`/`Paste`
- Check and log keyboard errors in the F7 handler, restoring clipboard on failure

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] Build POC on Windows: `go build -o ghosttype-poc.exe ./cmd/poc`
- [ ] Run POC, press F7 in Notepad
- [ ] Verify `ghosttype-poc.log` contains step-by-step trace with timestamps
- [ ] Verify `-log custom.log` flag writes to custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)