### PR TITLE
Remove logs/*.log gitignore rule so log files are tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ ghosttype
 
 # Runtime files
 ghosttype.log
-logs/*.log
 config.json
 
 # Test binary, built with `go test -c`


### PR DESCRIPTION
## Summary
- Remove `logs/*.log` from `.gitignore` so POC log files can be committed and shared for debugging

## Test plan
- [ ] Verify `git add logs/*.log` works without needing `-f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)