### PR TITLE
Add diagnostic tracing to hotkey message loop

### DIFF
--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -130,10 +130,22 @@ func RunWindowsLive() {
 	}
 	logInfo("F7 hotkey registered OK")
 
+	logInfo("Registering F8 diagnostic ping hotkey...")
+	err = hk.Register("ping", "F8", func() {
+		logInfo("F8 ping — hotkey delivery confirmed")
+		winBeep(600, 200)
+	})
+	if err != nil {
+		logError("Failed to register F8: %v", err)
+		return
+	}
+	logInfo("F8 hotkey registered OK")
+
 	logInfo("Registering Escape hotkey...")
 	err = hk.Register("quit", "Escape", func() {
 		logInfo("Escape pressed — exiting cleanly.")
 		hk.Unregister("correct")
+		hk.Unregister("ping")
 		hk.Unregister("quit")
 		os.Exit(0)
 	})
@@ -145,6 +157,7 @@ func RunWindowsLive() {
 
 	logInfo("F7 registered! Press F7 in any text field to test.")
 	logInfo("Text will be uppercased with [CORRECTED] prefix.")
+	logInfo("Press F8 to test hotkey delivery (ping)")
 	logInfo("Press Escape to exit.")
 
 	hk.Listen()

--- a/hotkey/hotkey_windows.go
+++ b/hotkey/hotkey_windows.go
@@ -4,6 +4,7 @@ package hotkey
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"sync"
 	"syscall"
@@ -106,11 +107,13 @@ func (m *WindowsManager) Register(name string, key string, handler Handler) erro
 	id := m.nextID
 	m.nextID++
 
-	ret, _, _ := procRegisterHotKey.Call(0, uintptr(id), uintptr(mod), uintptr(vk))
+	ret, _, err := procRegisterHotKey.Call(0, uintptr(id), uintptr(mod), uintptr(vk))
 	if ret == 0 {
+		log.Printf("[hotkey] RegisterHotKey FAILED for %q (key=%s id=%d mod=0x%X vk=0x%X): %v", name, key, id, mod, vk, err)
 		return fmt.Errorf("failed to register hotkey '%s' (id=%d)", key, id)
 	}
 
+	log.Printf("[hotkey] Registered %q: key=%s id=%d mod=0x%X vk=0x%X", name, key, id, mod, vk)
 	m.hotkeys[name] = registration{id: id, handler: handler}
 	return nil
 }
@@ -121,36 +124,50 @@ func (m *WindowsManager) Unregister(name string) error {
 
 	reg, ok := m.hotkeys[name]
 	if !ok {
+		log.Printf("[hotkey] Unregister %q: not found (no-op)", name)
 		return nil
 	}
 
+	log.Printf("[hotkey] Unregistering %q (id=%d)", name, reg.id)
 	procUnregisterHotKey.Call(0, uintptr(reg.id))
 	delete(m.hotkeys, name)
 	return nil
 }
 
 func (m *WindowsManager) Listen() error {
+	log.Printf("[hotkey] Entering message loop (registered hotkeys: %d)", len(m.hotkeys))
 	var message msg
 	for {
 		select {
 		case <-m.stopChan:
+			log.Printf("[hotkey] stopChan signalled — exiting message loop")
 			return nil
 		default:
 		}
 
 		ret, _, _ := procGetMessage.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
 		if ret == 0 {
+			log.Printf("[hotkey] GetMessage returned 0 (WM_QUIT) — exiting message loop")
 			break
 		}
 
+		log.Printf("[hotkey] GetMessage: msg=0x%04X wParam=0x%X lParam=0x%X", message.message, message.wParam, message.lParam)
+
 		if message.message == wmHotkey {
 			id := int(message.wParam)
+			log.Printf("[hotkey] WM_HOTKEY received: id=%d", id)
 			m.mu.Lock()
-			for _, reg := range m.hotkeys {
+			matched := false
+			for name, reg := range m.hotkeys {
 				if reg.id == id {
+					log.Printf("[hotkey] Dispatching handler for %q (id=%d)", name, id)
 					go reg.handler()
+					matched = true
 					break
 				}
+			}
+			if !matched {
+				log.Printf("[hotkey] WARNING: no registered handler for hotkey id=%d", id)
 			}
 			m.mu.Unlock()
 		}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.1.2"
+const Version = "0.1.3"


### PR DESCRIPTION
## Summary
- Add `log.Printf` tracing throughout `hotkey_windows.go` — Register, Listen (every message), Unregister
- Add F8 diagnostic ping hotkey to isolate whether delivery issues are F7-specific or systemic
- Bump version to v0.1.3

## Test plan
- [ ] Build on Windows, run POC, check logs for "Entering message loop" line
- [ ] Press F8 — should see "F8 ping — hotkey delivery confirmed" in log and hear beep
- [ ] Press F7 — check if WM_HOTKEY message appears in log (diagnoses delivery vs handler issue)
- [ ] Press Escape — verify clean exit with unregister logs for all three hotkeys

🤖 Generated with [Claude Code](https://claude.com/claude-code)