### PR TITLE
Fix version tracking and hotkey stall (Ctrl+B)

### DIFF
--- a/cmd/poc/main.go
+++ b/cmd/poc/main.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/chrixbedardcad/GhostType/internal/version"
 )
 
 var (
@@ -67,7 +69,7 @@ func main() {
 	log.SetFlags(log.Ldate | log.Ltime | log.Lmicroseconds)
 
 	log.Println("==============================================")
-	log.Println("  GhostType POC v0.1.2 — F7 Clipboard Workflow")
+	log.Printf("  GhostType POC v%s — Ctrl+G Clipboard Workflow", version.Version)
 	log.Println("  (No LLM — uses test message)")
 	log.Printf("  Log file: %s", *logFile)
 	log.Println("==============================================")

--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 	"time"
 
@@ -30,6 +31,11 @@ func runLive() {
 // RunWindowsLive registers Ctrl+G as a global hotkey and runs the clipboard
 // workflow with a simple test message (no LLM).
 func RunWindowsLive() {
+	// Windows RegisterHotKey and GetMessageW must run on the same OS thread.
+	// Without this, Go's scheduler can move the goroutine between threads,
+	// causing the message loop to stop receiving hotkey events after the first press.
+	runtime.LockOSThread()
+
 	logInfo("Creating clipboard, keyboard, hotkey managers")
 	cb := clipboard.NewWindowsClipboard()
 	kb := keyboard.NewWindowsSimulator()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,5 @@
+// Package version provides the single source of truth for GhostType's version string.
+// Both the main app and the POC binary import this package.
+package version
+
+const Version = "0.1.6"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,6 @@
 package main
 
-const Version = "0.1.5"
+import "github.com/chrixbedardcad/GhostType/internal/version"
+
+// Version re-exported from the single source of truth in internal/version.
+var Version = version.Version


### PR DESCRIPTION
## Summary
- **Version tracking**: Created shared `internal/version` package as single source of truth — both root app and POC binary import from it, eliminating hardcoded version strings (was stuck at `v0.1.2` in logs)
- **Hotkey stall fix**: Added `runtime.LockOSThread()` to `RunWindowsLive()` — Windows `RegisterHotKey` and `GetMessageW` must run on the same OS thread; without this, Go's scheduler migrates the goroutine after the first hotkey fires, causing the message loop to silently stop receiving events
- **Banner updated**: POC banner now shows dynamic version and correct hotkey name (Ctrl+G instead of F7)
- Version bumped to `0.1.6`

## Test plan
- [ ] Build on Windows: `go build -o ghosttype-poc.exe ./cmd/poc`
- [ ] Run and verify banner shows `v0.1.6 — Ctrl+G Clipboard Workflow`
- [ ] Press Ctrl+B multiple times — should beep every time without stalling
- [ ] Press Ctrl+G in a text field — full correction workflow runs
- [ ] Press Escape — clean exit
- [ ] Check log file — version in log matches `0.1.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)