### PR TITLE
Print captured/corrected text to console (issue #3)

### DIFF
--- a/cmd/poc/workflow_windows.go
+++ b/cmd/poc/workflow_windows.go
@@ -89,11 +89,11 @@ func RunWindowsLive() {
 			return
 		}
 
-		logDebug("Step 4: Clipboard text (%d chars): %q", len(text), text)
+		logInfo("Captured text (%d chars): %q", len(text), text)
 
 		// Step 5: Apply simple correction (no LLM)
 		corrected := correctText(text)
-		logDebug("Step 5: Corrected text: %q", corrected)
+		logInfo("Corrected text: %q", corrected)
 
 		// Step 6: Write result to clipboard
 		logDebug("Step 6: Writing corrected text to clipboard...")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.6"
+const Version = "0.1.7"


### PR DESCRIPTION
## Summary
- Promotes captured text and corrected text log lines from DEBUG to INFO level
- Addresses the issue #3 requirement: "Read clipboard content and print to console"
- Previously these were only visible with debug logging enabled — now they show in default console output and log files
- Bump version to 0.1.7

## Issue #3 status after this PR
All requirements satisfied:
- [x] Global hotkey registered (Ctrl+G)
- [x] Escape hotkey for clean exit
- [x] Ctrl+A → Ctrl+C with 50ms delays
- [x] **Read clipboard content and print to console** (this PR)
- [x] Convert text to uppercase (fake correction)
- [x] Write uppercase text to clipboard
- [x] Ctrl+A → Ctrl+V to paste back
- [x] Unregister hotkeys and exit cleanly on Escape
- [x] No CGO

## Test plan
- [ ] Build on Windows: `go build -o ghosttype-poc.exe ./cmd/poc`
- [ ] Open Notepad, type text, press Ctrl+G
- [ ] Verify console shows `INFO  Captured text (N chars): "..."` and `INFO  Corrected text: "..."`
- [ ] Verify same lines appear in the log file

🤖 Generated with [Claude Code](https://claude.com/claude-code)