### PR TITLE
Wire core correction workflow and add config.example.json

### DIFF
--- a/app_other.go
+++ b/app_other.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/chrixbedardcad/GhostType/config"
+	"github.com/chrixbedardcad/GhostType/mode"
+)
+
+func runApp(cfg *config.Config, router *mode.Router) {
+	fmt.Println("GhostType requires Windows for hotkey support.")
+	fmt.Println("On Windows, build and run:")
+	fmt.Println("  go build -o ghosttype.exe .")
+	fmt.Println("  ghosttype.exe")
+	fmt.Println()
+	fmt.Println("Press Ctrl+C to exit.")
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	<-sigChan
+
+	fmt.Println("\nGhostType shutting down.")
+}

--- a/app_windows.go
+++ b/app_windows.go
@@ -1,0 +1,178 @@
+//go:build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/chrixbedardcad/GhostType/clipboard"
+	"github.com/chrixbedardcad/GhostType/config"
+	"github.com/chrixbedardcad/GhostType/hotkey"
+	"github.com/chrixbedardcad/GhostType/keyboard"
+	"github.com/chrixbedardcad/GhostType/mode"
+)
+
+var (
+	kernel32Win = syscall.NewLazyDLL("kernel32.dll")
+	procBeep    = kernel32Win.NewProc("Beep")
+)
+
+// winBeep plays a short tone using the Windows Beep API.
+func winBeep(freq, durationMs uint32) {
+	procBeep.Call(uintptr(freq), uintptr(durationMs))
+}
+
+func runApp(cfg *config.Config, router *mode.Router) {
+	// Windows RegisterHotKey and GetMessageW must run on the same OS thread.
+	runtime.LockOSThread()
+
+	cb := clipboard.NewWindowsClipboard()
+	kb := keyboard.NewWindowsSimulator()
+	hk := hotkey.NewWindowsManager()
+
+	// Mutex-protected cancellation context for in-progress LLM calls.
+	var mu sync.Mutex
+	var cancelLLM context.CancelFunc
+
+	// Register correction hotkey (Ctrl+G).
+	err := hk.Register("correct", cfg.Hotkeys.Correct, func() {
+		slog.Info("Correction triggered")
+		winBeep(800, 100)
+
+		// Save original clipboard.
+		if err := cb.Save(); err != nil {
+			slog.Error("Failed to save clipboard", "error", err)
+			return
+		}
+
+		// Select all + copy.
+		if err := kb.SelectAll(); err != nil {
+			slog.Error("SelectAll failed", "error", err)
+			cb.Restore()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+
+		if err := kb.Copy(); err != nil {
+			slog.Error("Copy failed", "error", err)
+			cb.Restore()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+
+		// Read captured text.
+		text, err := cb.Read()
+		if err != nil {
+			slog.Error("Failed to read clipboard", "error", err)
+			cb.Restore()
+			return
+		}
+		if text == "" {
+			slog.Warn("Nothing to correct (empty text)")
+			cb.Restore()
+			return
+		}
+
+		slog.Info("Captured text", "len", len(text), "text", text)
+		fmt.Printf("Captured: %q\n", text)
+
+		// Create cancellable context with timeout.
+		timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+		mu.Lock()
+		cancelLLM = cancel
+		mu.Unlock()
+
+		defer func() {
+			cancel()
+			mu.Lock()
+			cancelLLM = nil
+			mu.Unlock()
+		}()
+
+		// Send to LLM via mode router.
+		corrected, err := router.Process(ctx, mode.ModeCorrect, text)
+		if err != nil {
+			slog.Error("LLM correction failed", "error", err)
+			cb.Restore()
+			return
+		}
+
+		// Write corrected text, select all, paste.
+		if err := cb.Write(corrected); err != nil {
+			slog.Error("Failed to write corrected text to clipboard", "error", err)
+			cb.Restore()
+			return
+		}
+
+		if err := kb.SelectAll(); err != nil {
+			slog.Error("SelectAll (paste prep) failed", "error", err)
+			cb.Restore()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+
+		if err := kb.Paste(); err != nil {
+			slog.Error("Paste failed", "error", err)
+			cb.Restore()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+
+		// Restore original clipboard.
+		cb.Restore()
+
+		winBeep(1200, 150)
+		slog.Info("Correction complete", "corrected", corrected)
+		fmt.Printf("Corrected: %q\n", corrected)
+	})
+	if err != nil {
+		slog.Error("Failed to register correction hotkey", "key", cfg.Hotkeys.Correct, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Correct, err)
+		return
+	}
+
+	// Register cancel hotkey (Escape) — cancels in-progress LLM call, does NOT exit.
+	err = hk.Register("cancel", cfg.Hotkeys.Cancel, func() {
+		mu.Lock()
+		fn := cancelLLM
+		mu.Unlock()
+
+		if fn != nil {
+			slog.Info("Cancel requested — aborting LLM call")
+			fn()
+		} else {
+			slog.Debug("Cancel pressed but no LLM call in progress")
+		}
+	})
+	if err != nil {
+		slog.Error("Failed to register cancel hotkey", "key", cfg.Hotkeys.Cancel, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Cancel, err)
+		return
+	}
+
+	// SIGINT handler — clean shutdown.
+	go func() {
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+		<-sigChan
+		fmt.Println("\nGhostType shutting down.")
+		slog.Info("GhostType shutting down")
+		hk.Stop()
+	}()
+
+	fmt.Println("GhostType is ready. Waiting for hotkey input...")
+	fmt.Println("Press Ctrl+C to exit.")
+
+	// Block on Windows message loop.
+	hk.Listen()
+}

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,46 @@
+{
+  "llm_provider": "anthropic",
+  "api_key": "YOUR_API_KEY_HERE",
+  "model": "claude-sonnet-4-5-20250929",
+  "api_endpoint": "",
+  "languages": ["en", "fr"],
+  "language_names": {
+    "en": "English",
+    "fr": "French"
+  },
+  "default_translate_target": "en",
+  "hotkeys": {
+    "correct": "Ctrl+G",
+    "translate": "F8",
+    "toggle_language": "Ctrl+F8",
+    "rewrite": "F9",
+    "cycle_template": "Ctrl+F9",
+    "cancel": "Escape"
+  },
+  "target_window": "Firestorm",
+  "prompts": {
+    "correct": "Detect the language of the following text (French or English). Fix all spelling and grammar errors while preserving the original meaning and language. Return ONLY the corrected text with no explanation.",
+    "translate": "Translate the following text to {target_language}. Preserve the tone and intent. Return ONLY the translation with no explanation.",
+    "rewrite_templates": [
+      {"name": "funny", "prompt": "Rewrite this as a funny, witty reply. Keep it short and punchy. Return ONLY the rewritten text."},
+      {"name": "formal", "prompt": "Rewrite this in a formal, professional tone. Return ONLY the rewritten text."},
+      {"name": "sarcastic", "prompt": "Rewrite this with heavy sarcasm. Return ONLY the rewritten text."},
+      {"name": "flirty", "prompt": "Rewrite this in a playful, flirty tone. Return ONLY the rewritten text."},
+      {"name": "poetic", "prompt": "Rewrite this as if you were a romantic poet. Return ONLY the rewritten text."}
+    ]
+  },
+  "overlay": {
+    "enabled": true,
+    "position": "above_chat",
+    "opacity": 0.85,
+    "auto_dismiss_seconds": 10,
+    "show_mode_indicator": true,
+    "highlight_changes": true,
+    "font_size": 14
+  },
+  "max_tokens": 256,
+  "timeout_ms": 5000,
+  "preserve_clipboard": true,
+  "log_level": "info",
+  "log_file": "ghosttype.log"
+}

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func DefaultConfig() Config {
 		},
 		DefaultTranslateTarget: "en",
 		Hotkeys: Hotkeys{
-			Correct:        "F7",
+			Correct:        "Ctrl+G",
 			Translate:      "F8",
 			ToggleLanguage: "Ctrl+F8",
 			Rewrite:        "F9",
@@ -172,7 +172,7 @@ func applyDefaults(cfg *Config) {
 		cfg.TargetWindow = "Firestorm"
 	}
 	if cfg.Hotkeys.Correct == "" {
-		cfg.Hotkeys.Correct = "F7"
+		cfg.Hotkeys.Correct = "Ctrl+G"
 	}
 	if cfg.Hotkeys.Cancel == "" {
 		cfg.Hotkeys.Cancel = "Escape"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,8 +22,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.TimeoutMs != 5000 {
 		t.Errorf("expected default timeout_ms 5000, got %d", cfg.TimeoutMs)
 	}
-	if cfg.Hotkeys.Correct != "F7" {
-		t.Errorf("expected default correct hotkey 'F7', got '%s'", cfg.Hotkeys.Correct)
+	if cfg.Hotkeys.Correct != "Ctrl+G" {
+		t.Errorf("expected default correct hotkey 'Ctrl+G', got '%s'", cfg.Hotkeys.Correct)
 	}
 	if cfg.Hotkeys.Translate != "F8" {
 		t.Errorf("expected default translate hotkey 'F8', got '%s'", cfg.Hotkeys.Translate)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.7"
+const Version = "0.1.8"

--- a/main.go
+++ b/main.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/chrixbedardcad/GhostType/config"
 	"github.com/chrixbedardcad/GhostType/llm"
@@ -94,9 +91,6 @@ func main() {
 	fmt.Printf("  %s - Rewrite\n", cfg.Hotkeys.Rewrite)
 	fmt.Printf("  %s - Cancel\n", cfg.Hotkeys.Cancel)
 	fmt.Println("")
-	fmt.Println("GhostType is ready. Waiting for hotkey input...")
-	fmt.Println("(Platform-specific hotkey hooks will be added in future builds)")
-	fmt.Println("Press Ctrl+C to exit.")
 
 	slog.Info("GhostType ready",
 		"hotkey_correct", cfg.Hotkeys.Correct,
@@ -104,17 +98,5 @@ func main() {
 		"hotkey_rewrite", cfg.Hotkeys.Rewrite,
 	)
 
-	// Keep the process alive, wait for termination signal
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	_ = ctx // Will be used for hotkey handlers
-	_ = router // Will be used for hotkey handlers
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
-
-	fmt.Println("\nGhostType shutting down.")
-	slog.Info("GhostType shutting down")
+	runApp(cfg, router)
 }


### PR DESCRIPTION
## Summary
- **Issue #11**: Wires the full correction workflow — Ctrl+G triggers clipboard capture → LLM correction via `mode.Router.Process()` → paste back. Escape cancels in-progress LLM calls (Ctrl+C exits).
- **Issue #4**: Adds `config.example.json` with `YOUR_API_KEY_HERE` placeholder so users know the config schema.
- Updates default correct hotkey from `F7` to `Ctrl+G` in `DefaultConfig()` and `applyDefaults()`.
- Bumps version to `v0.1.8`.

### Files changed
| File | Change |
|------|--------|
| `app_windows.go` | New — Windows hotkey + LLM correction workflow |
| `app_other.go` | New — non-Windows fallback (prints unsupported message) |
| `main.go` | Calls `runApp()` instead of blocking on SIGINT |
| `config.example.json` | New — example config with placeholder API key |
| `config/config.go` | Default correct hotkey → `Ctrl+G` |
| `config/config_test.go` | Updated test expectation |
| `internal/version/version.go` | `0.1.7` → `0.1.8` |

## Test plan
- [ ] `go vet ./...` — no errors ✅
- [ ] `go test ./...` — all pass ✅
- [ ] `GOOS=windows GOARCH=amd64 go build .` — cross-compile succeeds ✅
- [ ] Copy `config.example.json` to `config.json`, replace `"YOUR_API_KEY_HERE"` in the `"api_key"` field with your real Anthropic API key
- [ ] On Windows: build `ghosttype.exe`, open a text field, type misspelled text, press Ctrl+G → text is corrected via LLM
- [ ] On Windows: press Escape during LLM call → call is cancelled, original text preserved
- [ ] On Windows: press Ctrl+C → clean shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)