### PR TITLE
Add CTRL+J bilingual translation, configurable hotkeys, fix logging

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -30,6 +30,111 @@ func winBeep(freq, durationMs uint32) {
 	procBeep.Call(uintptr(freq), uintptr(durationMs))
 }
 
+// processMode captures text from the active window, sends it through the LLM
+// with the given mode, and pastes the result back. This is the shared workflow
+// for correction, translation, and rewrite hotkeys.
+func processMode(
+	modeName string,
+	m mode.Mode,
+	cfg *config.Config,
+	router *mode.Router,
+	cb *clipboard.WindowsClipboard,
+	kb *keyboard.WindowsSimulator,
+	mu *sync.Mutex,
+	cancelLLM *context.CancelFunc,
+) {
+	slog.Info(modeName + " triggered")
+	winBeep(800, 100)
+
+	// Save original clipboard.
+	if err := cb.Save(); err != nil {
+		slog.Error("Failed to save clipboard", "mode", modeName, "error", err)
+		return
+	}
+
+	// Select all + copy.
+	if err := kb.SelectAll(); err != nil {
+		slog.Error("SelectAll failed", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if err := kb.Copy(); err != nil {
+		slog.Error("Copy failed", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	// Read captured text.
+	text, err := cb.Read()
+	if err != nil {
+		slog.Error("Failed to read clipboard", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+	if text == "" {
+		slog.Warn("Nothing to process (empty text)", "mode", modeName)
+		cb.Restore()
+		return
+	}
+
+	slog.Info("Captured text", "mode", modeName, "len", len(text), "text", text)
+	fmt.Printf("[%s] Captured: %q\n", modeName, text)
+
+	// Create cancellable context with timeout.
+	timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	mu.Lock()
+	*cancelLLM = cancel
+	mu.Unlock()
+
+	defer func() {
+		cancel()
+		mu.Lock()
+		*cancelLLM = nil
+		mu.Unlock()
+	}()
+
+	// Send to LLM via mode router.
+	result, err := router.Process(ctx, m, text)
+	if err != nil {
+		slog.Error("LLM processing failed", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+
+	// Write result, select all, paste.
+	if err := cb.Write(result); err != nil {
+		slog.Error("Failed to write result to clipboard", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+
+	if err := kb.SelectAll(); err != nil {
+		slog.Error("SelectAll (paste prep) failed", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if err := kb.Paste(); err != nil {
+		slog.Error("Paste failed", "mode", modeName, "error", err)
+		cb.Restore()
+		return
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Restore original clipboard.
+	cb.Restore()
+
+	winBeep(1200, 150)
+	slog.Info(modeName+" complete", "result", result)
+	fmt.Printf("[%s] Result: %q\n", modeName, result)
+}
+
 func runApp(cfg *config.Config, router *mode.Router) {
 	// Windows RegisterHotKey and GetMessageW must run on the same OS thread.
 	runtime.LockOSThread()
@@ -42,98 +147,9 @@ func runApp(cfg *config.Config, router *mode.Router) {
 	var mu sync.Mutex
 	var cancelLLM context.CancelFunc
 
-	// Register correction hotkey (Ctrl+G).
+	// Register correction hotkey.
 	err := hk.Register("correct", cfg.Hotkeys.Correct, func() {
-		slog.Info("Correction triggered")
-		winBeep(800, 100)
-
-		// Save original clipboard.
-		if err := cb.Save(); err != nil {
-			slog.Error("Failed to save clipboard", "error", err)
-			return
-		}
-
-		// Select all + copy.
-		if err := kb.SelectAll(); err != nil {
-			slog.Error("SelectAll failed", "error", err)
-			cb.Restore()
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-
-		if err := kb.Copy(); err != nil {
-			slog.Error("Copy failed", "error", err)
-			cb.Restore()
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-
-		// Read captured text.
-		text, err := cb.Read()
-		if err != nil {
-			slog.Error("Failed to read clipboard", "error", err)
-			cb.Restore()
-			return
-		}
-		if text == "" {
-			slog.Warn("Nothing to correct (empty text)")
-			cb.Restore()
-			return
-		}
-
-		slog.Info("Captured text", "len", len(text), "text", text)
-		fmt.Printf("Captured: %q\n", text)
-
-		// Create cancellable context with timeout.
-		timeout := time.Duration(cfg.TimeoutMs) * time.Millisecond
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-
-		mu.Lock()
-		cancelLLM = cancel
-		mu.Unlock()
-
-		defer func() {
-			cancel()
-			mu.Lock()
-			cancelLLM = nil
-			mu.Unlock()
-		}()
-
-		// Send to LLM via mode router.
-		corrected, err := router.Process(ctx, mode.ModeCorrect, text)
-		if err != nil {
-			slog.Error("LLM correction failed", "error", err)
-			cb.Restore()
-			return
-		}
-
-		// Write corrected text, select all, paste.
-		if err := cb.Write(corrected); err != nil {
-			slog.Error("Failed to write corrected text to clipboard", "error", err)
-			cb.Restore()
-			return
-		}
-
-		if err := kb.SelectAll(); err != nil {
-			slog.Error("SelectAll (paste prep) failed", "error", err)
-			cb.Restore()
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-
-		if err := kb.Paste(); err != nil {
-			slog.Error("Paste failed", "error", err)
-			cb.Restore()
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-
-		// Restore original clipboard.
-		cb.Restore()
-
-		winBeep(1200, 150)
-		slog.Info("Correction complete", "corrected", corrected)
-		fmt.Printf("Corrected: %q\n", corrected)
+		processMode("Correction", mode.ModeCorrect, cfg, router, cb, kb, &mu, &cancelLLM)
 	})
 	if err != nil {
 		slog.Error("Failed to register correction hotkey", "key", cfg.Hotkeys.Correct, "error", err)
@@ -141,7 +157,53 @@ func runApp(cfg *config.Config, router *mode.Router) {
 		return
 	}
 
-	// Register cancel hotkey (Escape) — cancels in-progress LLM call, does NOT exit.
+	// Register translation hotkey.
+	err = hk.Register("translate", cfg.Hotkeys.Translate, func() {
+		processMode("Translation", mode.ModeTranslate, cfg, router, cb, kb, &mu, &cancelLLM)
+	})
+	if err != nil {
+		slog.Error("Failed to register translate hotkey", "key", cfg.Hotkeys.Translate, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Translate, err)
+		return
+	}
+
+	// Register toggle-language hotkey — cycles translation target, no LLM call.
+	err = hk.Register("toggle_language", cfg.Hotkeys.ToggleLanguage, func() {
+		name := router.ToggleTranslateTarget()
+		slog.Info("Translation target toggled", "target", name)
+		fmt.Printf("Translation target: %s\n", name)
+		winBeep(600, 80)
+	})
+	if err != nil {
+		slog.Error("Failed to register toggle-language hotkey", "key", cfg.Hotkeys.ToggleLanguage, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.ToggleLanguage, err)
+		return
+	}
+
+	// Register rewrite hotkey.
+	err = hk.Register("rewrite", cfg.Hotkeys.Rewrite, func() {
+		processMode("Rewrite", mode.ModeRewrite, cfg, router, cb, kb, &mu, &cancelLLM)
+	})
+	if err != nil {
+		slog.Error("Failed to register rewrite hotkey", "key", cfg.Hotkeys.Rewrite, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Rewrite, err)
+		return
+	}
+
+	// Register cycle-template hotkey — cycles rewrite template, no LLM call.
+	err = hk.Register("cycle_template", cfg.Hotkeys.CycleTemplate, func() {
+		name := router.CycleTemplate()
+		slog.Info("Rewrite template cycled", "template", name)
+		fmt.Printf("Rewrite template: %s\n", name)
+		winBeep(600, 80)
+	})
+	if err != nil {
+		slog.Error("Failed to register cycle-template hotkey", "key", cfg.Hotkeys.CycleTemplate, "error", err)
+		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.CycleTemplate, err)
+		return
+	}
+
+	// Register cancel hotkey — cancels in-progress LLM call, does NOT exit.
 	err = hk.Register("cancel", cfg.Hotkeys.Cancel, func() {
 		mu.Lock()
 		fn := cancelLLM

--- a/config.example.json
+++ b/config.example.json
@@ -11,7 +11,7 @@
   "default_translate_target": "en",
   "hotkeys": {
     "correct": "Ctrl+G",
-    "translate": "F8",
+    "translate": "Ctrl+J",
     "toggle_language": "Ctrl+F8",
     "rewrite": "F9",
     "cycle_template": "Ctrl+F9",
@@ -19,7 +19,7 @@
   },
   "prompts": {
     "correct": "Detect the language of the following text (French or English). Fix all spelling and grammar errors while preserving the original meaning and language. Return ONLY the corrected text with no explanation.",
-    "translate": "Translate the following text to {target_language}. Preserve the tone and intent. Return ONLY the translation with no explanation.",
+    "translate": "The two configured languages are {language_a} and {language_b}. Detect the language of the following text and translate it to the OTHER language. If it is {language_a}, translate to {language_b}. If it is {language_b}, translate to {language_a}. Preserve the tone and intent. Return ONLY the translation with no explanation.",
     "rewrite_templates": [
       {"name": "funny", "prompt": "Rewrite this as a funny, witty reply. Keep it short and punchy. Return ONLY the rewritten text."},
       {"name": "formal", "prompt": "Rewrite this in a formal, professional tone. Return ONLY the rewritten text."},

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func DefaultConfig() Config {
 		DefaultTranslateTarget: "en",
 		Hotkeys: Hotkeys{
 			Correct:        "Ctrl+G",
-			Translate:      "F8",
+			Translate:      "Ctrl+J",
 			ToggleLanguage: "Ctrl+F8",
 			Rewrite:        "F9",
 			CycleTemplate:  "Ctrl+F9",
@@ -84,7 +84,7 @@ func DefaultConfig() Config {
 		},
 		Prompts: Prompts{
 			Correct:   "Detect the language of the following text (French or English). Fix all spelling and grammar errors while preserving the original meaning and language. Return ONLY the corrected text with no explanation.",
-			Translate: "Translate the following text to {target_language}. Preserve the tone and intent. Return ONLY the translation with no explanation.",
+			Translate: "The two configured languages are {language_a} and {language_b}. Detect the language of the following text and translate it to the OTHER language. If it is {language_a}, translate to {language_b}. If it is {language_b}, translate to {language_a}. Preserve the tone and intent. Return ONLY the translation with no explanation.",
 			RewriteTemplates: []RewriteTemplate{
 				{Name: "funny", Prompt: "Rewrite this as a funny, witty reply. Keep it short and punchy. Return ONLY the rewritten text."},
 				{Name: "formal", Prompt: "Rewrite this in a formal, professional tone. Return ONLY the rewritten text."},
@@ -160,14 +160,25 @@ func applyDefaults(cfg *Config) {
 	if cfg.TimeoutMs == 0 {
 		cfg.TimeoutMs = 5000
 	}
-	if cfg.LogLevel == "" {
-		cfg.LogLevel = "info"
-	}
-	if cfg.LogFile == "" {
+	// LogLevel: empty means disabled (no logging). No default applied.
+	// LogFile: only default if logging is enabled.
+	if cfg.LogLevel != "" && cfg.LogFile == "" {
 		cfg.LogFile = "ghosttype.log"
 	}
 	if cfg.Hotkeys.Correct == "" {
 		cfg.Hotkeys.Correct = "Ctrl+G"
+	}
+	if cfg.Hotkeys.Translate == "" {
+		cfg.Hotkeys.Translate = "Ctrl+J"
+	}
+	if cfg.Hotkeys.ToggleLanguage == "" {
+		cfg.Hotkeys.ToggleLanguage = "Ctrl+F8"
+	}
+	if cfg.Hotkeys.Rewrite == "" {
+		cfg.Hotkeys.Rewrite = "F9"
+	}
+	if cfg.Hotkeys.CycleTemplate == "" {
+		cfg.Hotkeys.CycleTemplate = "Ctrl+F9"
 	}
 	if cfg.Hotkeys.Cancel == "" {
 		cfg.Hotkeys.Cancel = "Escape"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,8 +25,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Hotkeys.Correct != "Ctrl+G" {
 		t.Errorf("expected default correct hotkey 'Ctrl+G', got '%s'", cfg.Hotkeys.Correct)
 	}
-	if cfg.Hotkeys.Translate != "F8" {
-		t.Errorf("expected default translate hotkey 'F8', got '%s'", cfg.Hotkeys.Translate)
+	if cfg.Hotkeys.Translate != "Ctrl+J" {
+		t.Errorf("expected default translate hotkey 'Ctrl+J', got '%s'", cfg.Hotkeys.Translate)
 	}
 	if cfg.Hotkeys.Rewrite != "F9" {
 		t.Errorf("expected default rewrite hotkey 'F9', got '%s'", cfg.Hotkeys.Rewrite)
@@ -198,8 +198,61 @@ func TestLoadAppliesDefaults(t *testing.T) {
 	if loaded.TimeoutMs != 5000 {
 		t.Errorf("expected default timeout_ms 5000, got %d", loaded.TimeoutMs)
 	}
-	if loaded.LogLevel != "info" {
-		t.Errorf("expected default log_level 'info', got '%s'", loaded.LogLevel)
+	if loaded.LogLevel != "" {
+		t.Errorf("expected empty log_level (disabled by default), got '%s'", loaded.LogLevel)
+	}
+}
+
+func TestLoadLoggingDisabledByDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.LogLevel != "" {
+		t.Errorf("expected empty log_level when not set, got '%s'", loaded.LogLevel)
+	}
+	if loaded.LogFile != "" {
+		t.Errorf("expected empty log_file when logging disabled, got '%s'", loaded.LogFile)
+	}
+}
+
+func TestLoadLoggingEnabledSetsLogFileDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"log_level":    "debug",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.LogLevel != "debug" {
+		t.Errorf("expected log_level 'debug', got '%s'", loaded.LogLevel)
+	}
+	if loaded.LogFile != "ghosttype.log" {
+		t.Errorf("expected default log_file 'ghosttype.log', got '%s'", loaded.LogFile)
 	}
 }
 

--- a/hotkey/hotkey_windows.go
+++ b/hotkey/hotkey_windows.go
@@ -4,7 +4,7 @@ package hotkey
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"syscall"
@@ -27,6 +27,7 @@ const (
 	vkEscape = 0x1B
 	vkB      = 0x42
 	vkG      = 0x47
+	vkJ      = 0x4A
 	vkF7     = 0x76
 	vkF8     = 0x77
 	vkF9     = 0x78
@@ -93,6 +94,7 @@ func parseKey(key string) (uint32, uint32, error) {
 var keyMap = map[string]uint32{
 	"b":      vkB,
 	"g":      vkG,
+	"j":      vkJ,
 	"f7":     vkF7,
 	"f8":     vkF8,
 	"f9":     vkF9,
@@ -113,11 +115,11 @@ func (m *WindowsManager) Register(name string, key string, handler Handler) erro
 
 	ret, _, err := procRegisterHotKey.Call(0, uintptr(id), uintptr(mod), uintptr(vk))
 	if ret == 0 {
-		log.Printf("[hotkey] RegisterHotKey FAILED for %q (key=%s id=%d mod=0x%X vk=0x%X): %v", name, key, id, mod, vk, err)
+		slog.Error("RegisterHotKey failed", "name", name, "key", key, "id", id, "mod", fmt.Sprintf("0x%X", mod), "vk", fmt.Sprintf("0x%X", vk), "error", err)
 		return fmt.Errorf("failed to register hotkey '%s' (id=%d)", key, id)
 	}
 
-	log.Printf("[hotkey] Registered %q: key=%s id=%d mod=0x%X vk=0x%X", name, key, id, mod, vk)
+	slog.Debug("Hotkey registered", "name", name, "key", key, "id", id, "mod", fmt.Sprintf("0x%X", mod), "vk", fmt.Sprintf("0x%X", vk))
 	m.hotkeys[name] = registration{id: id, handler: handler}
 	return nil
 }
@@ -128,50 +130,50 @@ func (m *WindowsManager) Unregister(name string) error {
 
 	reg, ok := m.hotkeys[name]
 	if !ok {
-		log.Printf("[hotkey] Unregister %q: not found (no-op)", name)
+		slog.Debug("Hotkey unregister: not found (no-op)", "name", name)
 		return nil
 	}
 
-	log.Printf("[hotkey] Unregistering %q (id=%d)", name, reg.id)
+	slog.Debug("Hotkey unregistering", "name", name, "id", reg.id)
 	procUnregisterHotKey.Call(0, uintptr(reg.id))
 	delete(m.hotkeys, name)
 	return nil
 }
 
 func (m *WindowsManager) Listen() error {
-	log.Printf("[hotkey] Entering message loop (registered hotkeys: %d)", len(m.hotkeys))
+	slog.Debug("Entering message loop", "registered_hotkeys", len(m.hotkeys))
 	var message msg
 	for {
 		select {
 		case <-m.stopChan:
-			log.Printf("[hotkey] stopChan signalled — exiting message loop")
+			slog.Debug("stopChan signalled — exiting message loop")
 			return nil
 		default:
 		}
 
 		ret, _, _ := procGetMessage.Call(uintptr(unsafe.Pointer(&message)), 0, 0, 0)
 		if ret == 0 {
-			log.Printf("[hotkey] GetMessage returned 0 (WM_QUIT) — exiting message loop")
+			slog.Debug("GetMessage returned 0 (WM_QUIT) — exiting message loop")
 			break
 		}
 
-		log.Printf("[hotkey] GetMessage: msg=0x%04X wParam=0x%X lParam=0x%X", message.message, message.wParam, message.lParam)
+		slog.Debug("GetMessage", "msg", fmt.Sprintf("0x%04X", message.message), "wParam", fmt.Sprintf("0x%X", message.wParam), "lParam", fmt.Sprintf("0x%X", message.lParam))
 
 		if message.message == wmHotkey {
 			id := int(message.wParam)
-			log.Printf("[hotkey] WM_HOTKEY received: id=%d", id)
+			slog.Debug("WM_HOTKEY received", "id", id)
 			m.mu.Lock()
 			matched := false
 			for name, reg := range m.hotkeys {
 				if reg.id == id {
-					log.Printf("[hotkey] Dispatching handler for %q (id=%d)", name, id)
+					slog.Debug("Dispatching hotkey handler", "name", name, "id", id)
 					go reg.handler()
 					matched = true
 					break
 				}
 			}
 			if !matched {
-				log.Printf("[hotkey] WARNING: no registered handler for hotkey id=%d", id)
+				slog.Warn("No registered handler for hotkey", "id", id)
 			}
 			m.mu.Unlock()
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.10"
+const Version = "0.1.12"

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -36,27 +37,40 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set up logging
-	logLevel := slog.LevelInfo
-	switch cfg.LogLevel {
-	case "debug":
-		logLevel = slog.LevelDebug
-	case "warn":
-		logLevel = slog.LevelWarn
-	case "error":
-		logLevel = slog.LevelError
-	}
+	// Set up logging. Empty log_level disables all logging.
+	if cfg.LogLevel != "" {
+		logLevel := slog.LevelInfo
+		switch cfg.LogLevel {
+		case "debug":
+			logLevel = slog.LevelDebug
+		case "warn":
+			logLevel = slog.LevelWarn
+		case "error":
+			logLevel = slog.LevelError
+		}
 
-	logFile, err := os.OpenFile(cfg.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: could not open log file %s: %v\n", cfg.LogFile, err)
-		logFile = os.Stderr
+		// Resolve log file path relative to the executable directory.
+		logPath := cfg.LogFile
+		if !filepath.IsAbs(logPath) {
+			logPath = filepath.Join(filepath.Dir(execPath), logPath)
+		}
+
+		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not open log file %s: %v\n", logPath, err)
+			logFile = os.Stderr
+		} else {
+			defer logFile.Close()
+		}
+
+		logger := slog.New(slog.NewTextHandler(logFile, &slog.HandlerOptions{Level: logLevel}))
+		slog.SetDefault(logger)
+		fmt.Printf("Logging enabled: level=%s file=%s\n", cfg.LogLevel, logPath)
 	} else {
-		defer logFile.Close()
+		// Disabled: set a no-op logger that discards everything.
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
+		fmt.Println("Logging disabled (log_level is empty)")
 	}
-
-	logger := slog.New(slog.NewTextHandler(logFile, &slog.HandlerOptions{Level: logLevel}))
-	slog.SetDefault(logger)
 
 	slog.Info("GhostType starting",
 		"provider", cfg.LLMProvider,

--- a/mode/router.go
+++ b/mode/router.go
@@ -98,14 +98,35 @@ func (r *Router) Process(ctx context.Context, mode Mode, text string) (string, e
 	return strings.TrimSpace(resp.Text), nil
 }
 
-// buildTranslatePrompt builds the translation prompt with the current target language.
+// buildTranslatePrompt builds the bilingual translation prompt.
+// It substitutes {language_a} and {language_b} from the configured language pair.
+// Also supports legacy {target_language} placeholder for backwards compatibility.
 func (r *Router) buildTranslatePrompt() string {
+	prompt := r.cfg.Prompts.Translate
+
+	// Populate language pair placeholders for bilingual auto-detection.
+	if len(r.cfg.Languages) >= 2 {
+		nameA := r.cfg.LanguageNames[r.cfg.Languages[0]]
+		if nameA == "" {
+			nameA = r.cfg.Languages[0]
+		}
+		nameB := r.cfg.LanguageNames[r.cfg.Languages[1]]
+		if nameB == "" {
+			nameB = r.cfg.Languages[1]
+		}
+		prompt = strings.ReplaceAll(prompt, "{language_a}", nameA)
+		prompt = strings.ReplaceAll(prompt, "{language_b}", nameB)
+	}
+
+	// Legacy support: also replace {target_language} if present.
 	targetLang := r.CurrentTranslateTarget()
 	targetName := r.cfg.LanguageNames[targetLang]
 	if targetName == "" {
 		targetName = targetLang
 	}
-	return strings.ReplaceAll(r.cfg.Prompts.Translate, "{target_language}", targetName)
+	prompt = strings.ReplaceAll(prompt, "{target_language}", targetName)
+
+	return prompt
 }
 
 // buildRewritePrompt returns the prompt for the current rewrite template.

--- a/mode/router_test.go
+++ b/mode/router_test.go
@@ -35,7 +35,7 @@ func newTestConfig() *config.Config {
 		DefaultTranslateTarget: "en",
 		Prompts: config.Prompts{
 			Correct:   "Fix spelling and grammar. Return ONLY corrected text.",
-			Translate: "Translate to {target_language}. Return ONLY the translation.",
+			Translate: "Detect language and translate between {language_a} and {language_b}. Return ONLY the translation.",
 			RewriteTemplates: []config.RewriteTemplate{
 				{Name: "funny", Prompt: "Rewrite as funny. Return ONLY the text."},
 				{Name: "formal", Prompt: "Rewrite as formal. Return ONLY the text."},
@@ -84,9 +84,10 @@ func TestRouter_ProcessTranslate(t *testing.T) {
 		t.Errorf("expected translated text, got '%s'", result)
 	}
 
-	// Verify prompt was built with target language
-	if mock.lastReq.Prompt != "Translate to English. Return ONLY the translation." {
-		t.Errorf("expected prompt with English target, got '%s'", mock.lastReq.Prompt)
+	// Verify prompt was built with language pair
+	expectedPrompt := "Detect language and translate between English and French. Return ONLY the translation."
+	if mock.lastReq.Prompt != expectedPrompt {
+		t.Errorf("expected prompt %q, got %q", expectedPrompt, mock.lastReq.Prompt)
 	}
 }
 
@@ -196,6 +197,60 @@ func TestRouter_CycleTemplate(t *testing.T) {
 	name = router.CycleTemplate()
 	if name != "funny" {
 		t.Errorf("expected 'funny', got '%s'", name)
+	}
+}
+
+func TestRouter_BilingualTranslatePrompt(t *testing.T) {
+	cfg := &config.Config{
+		Languages:              []string{"en", "fr"},
+		LanguageNames:          map[string]string{"en": "English", "fr": "French"},
+		DefaultTranslateTarget: "en",
+		Prompts: config.Prompts{
+			Correct:   "Fix errors.",
+			Translate: "Languages are {language_a} and {language_b}. Detect and translate.",
+		},
+		MaxTokens: 256,
+	}
+	mock := &mockClient{
+		response: &llm.Response{Text: "translated", Provider: "mock", Model: "test"},
+	}
+	router := NewRouter(cfg, mock)
+
+	_, err := router.Process(context.Background(), ModeTranslate, "Bonjour")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "Languages are English and French. Detect and translate."
+	if mock.lastReq.Prompt != expected {
+		t.Errorf("expected prompt %q, got %q", expected, mock.lastReq.Prompt)
+	}
+}
+
+func TestRouter_TranslateLegacyTargetLanguage(t *testing.T) {
+	cfg := &config.Config{
+		Languages:              []string{"en", "fr"},
+		LanguageNames:          map[string]string{"en": "English", "fr": "French"},
+		DefaultTranslateTarget: "en",
+		Prompts: config.Prompts{
+			Correct:   "Fix errors.",
+			Translate: "Translate to {target_language}.",
+		},
+		MaxTokens: 256,
+	}
+	mock := &mockClient{
+		response: &llm.Response{Text: "translated", Provider: "mock", Model: "test"},
+	}
+	router := NewRouter(cfg, mock)
+
+	_, err := router.Process(context.Background(), ModeTranslate, "Hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "Translate to English."
+	if mock.lastReq.Prompt != expected {
+		t.Errorf("expected prompt %q, got %q", expected, mock.lastReq.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Bilingual translation (CTRL+J)**: Auto-detects the input language from the configured pair (e.g. `en/fr`) and translates to the opposite language. No need to manually toggle — just press CTRL+J and it figures out the direction.
- **All hotkeys now configurable**: Correction, translate, toggle_language, rewrite, cycle_template, and cancel can all be customized in `config.json`. All 6 hotkeys are now wired up (previously only correction and cancel were registered).
- **Logging fix**: Empty `log_level` (or removed field) disables logging entirely. When enabled, log file is resolved relative to the exe directory. Migrated `hotkey_windows.go` from `log.Printf` to `slog` so all logs go through the configured logger.

Addresses #36

## Changes

| File | What changed |
|---|---|
| `config/config.go` | Default translate hotkey `F8` → `Ctrl+J`, bilingual prompt with `{language_a}/{language_b}`, defaults for all hotkeys, empty `log_level` = disabled |
| `hotkey/hotkey_windows.go` | Added `vkJ`/`"j"` to keyMap, migrated `log.Printf` → `slog` |
| `app_windows.go` | Extracted `processMode()` helper, registered all 6 hotkeys |
| `mode/router.go` | `buildTranslatePrompt()` supports `{language_a}/{language_b}` + legacy `{target_language}` |
| `main.go` | Conditional logging setup, log file resolved relative to exe dir, no-op logger when disabled |
| `config.example.json` | Updated defaults |
| `mode/router_test.go` | Added `TestRouter_BilingualTranslatePrompt`, `TestRouter_TranslateLegacyTargetLanguage` |
| `config/config_test.go` | Added `TestLoadLoggingDisabledByDefault`, `TestLoadLoggingEnabledSetsLogFileDefault` |
| `internal/version/version.go` | `0.1.10` → `0.1.12` |

## Test plan

- [x] All 32 unit tests pass (`go test ./config/ ./mode/ ./llm/`)
- [ ] Configure `en/fr` pair, press CTRL+J on English text → French output
- [ ] Press CTRL+J on French text → English output
- [ ] Override hotkeys in config, verify custom bindings work
- [ ] Set `log_level: "debug"` → verify `ghosttype.log` appears next to exe with entries
- [ ] Remove `log_level` or set `""` → verify no log file created
- [ ] Test rewrite (F9) and cycle-template (Ctrl+F9) hotkeys

🤖 Generated with [Claude Code](https://claude.com/claude-code)