### PR TITLE
Fix compile error: clipboard.WindowsClipboard → clipboard.Clipboard

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -38,7 +38,7 @@ func processMode(
 	m mode.Mode,
 	cfg *config.Config,
 	router *mode.Router,
-	cb *clipboard.WindowsClipboard,
+	cb *clipboard.Clipboard,
 	kb *keyboard.WindowsSimulator,
 	mu *sync.Mutex,
 	cancelLLM *context.CancelFunc,


### PR DESCRIPTION
## Summary

- Fixes compile error introduced in PR #37: `processMode` referenced `*clipboard.WindowsClipboard` which doesn't exist — the correct type is `*clipboard.Clipboard`

Addresses #36

## Changes

| File | What changed |
|---|---|
| `app_windows.go` | Changed `*clipboard.WindowsClipboard` → `*clipboard.Clipboard` in `processMode` signature |

## Test plan

- [x] `go vet ./...` passes
- [x] All 32 unit tests pass
- [ ] `go build -o ghosttype.exe .` compiles successfully on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)