### PR TITLE
Fix logging path resolution and add log_level validation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // RewriteTemplate defines a named rewrite prompt template.
@@ -160,6 +161,8 @@ func applyDefaults(cfg *Config) {
 	if cfg.TimeoutMs == 0 {
 		cfg.TimeoutMs = 5000
 	}
+	// Normalize log_level to lowercase so "Debug", "INFO", etc. all work.
+	cfg.LogLevel = strings.ToLower(strings.TrimSpace(cfg.LogLevel))
 	// LogLevel: empty means disabled (no logging). No default applied.
 	// LogFile: only default if logging is enabled.
 	if cfg.LogLevel != "" && cfg.LogFile == "" {
@@ -219,6 +222,19 @@ func validate(cfg *Config) error {
 
 	if cfg.Prompts.Correct == "" {
 		return fmt.Errorf("prompts.correct is required")
+	}
+
+	// Validate log_level if set.
+	if cfg.LogLevel != "" {
+		validLevels := map[string]bool{
+			"debug": true,
+			"info":  true,
+			"warn":  true,
+			"error": true,
+		}
+		if !validLevels[cfg.LogLevel] {
+			return fmt.Errorf("unsupported log_level: %q (valid: debug, info, warn, error, or empty to disable)", cfg.LogLevel)
+		}
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -256,6 +256,53 @@ func TestLoadLoggingEnabledSetsLogFileDefault(t *testing.T) {
 	}
 }
 
+func TestLoadLogLevelCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"log_level":    "DEBUG",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.LogLevel != "debug" {
+		t.Errorf("expected normalized log_level 'debug', got '%s'", loaded.LogLevel)
+	}
+	if loaded.LogFile != "ghosttype.log" {
+		t.Errorf("expected default log_file 'ghosttype.log', got '%s'", loaded.LogFile)
+	}
+}
+
+func TestLoadInvalidLogLevel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"log_level":    "verbose",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected validation error for invalid log_level")
+	}
+}
+
 func TestWriteDefault(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "config.json")

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.12"
+const Version = "0.1.13"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/chrixbedardcad/GhostType/config"
 	"github.com/chrixbedardcad/GhostType/llm"
@@ -16,19 +17,24 @@ func main() {
 	fmt.Printf("GhostType v%s - AI-powered multilingual auto-correction\n", Version)
 	fmt.Println("====================================================")
 
-	// Determine config path (same directory as executable)
+	// Determine config path (same directory as executable, then CWD).
 	execPath, err := os.Executable()
 	if err != nil {
 		execPath = "."
 	}
 	configPath := filepath.Join(filepath.Dir(execPath), "config.json")
 
-	// Also check current working directory
+	// Fall back to current working directory.
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		configPath = "config.json"
 	}
 
-	// Load configuration
+	// Resolve to absolute so log messages always show the full path.
+	if absPath, err := filepath.Abs(configPath); err == nil {
+		configPath = absPath
+	}
+
+	// Load configuration.
 	fmt.Printf("Loading config from: %s\n", configPath)
 	cfg, err := config.Load(configPath)
 	if err != nil {
@@ -37,27 +43,43 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Derive the base directory from the config file for resolving relative paths.
+	configDir := filepath.Dir(configPath)
+
 	// Set up logging. Empty log_level disables all logging.
+	// Normalize to lowercase so "Debug", "DEBUG", etc. all work.
+	cfg.LogLevel = strings.ToLower(strings.TrimSpace(cfg.LogLevel))
+
 	if cfg.LogLevel != "" {
 		logLevel := slog.LevelInfo
 		switch cfg.LogLevel {
 		case "debug":
 			logLevel = slog.LevelDebug
+		case "info":
+			logLevel = slog.LevelInfo
 		case "warn":
 			logLevel = slog.LevelWarn
 		case "error":
 			logLevel = slog.LevelError
 		}
 
-		// Resolve log file path relative to the executable directory.
+		// Resolve log file path relative to the config file directory.
 		logPath := cfg.LogFile
 		if !filepath.IsAbs(logPath) {
-			logPath = filepath.Join(filepath.Dir(execPath), logPath)
+			logPath = filepath.Join(configDir, logPath)
+		}
+
+		// Ensure the parent directory exists.
+		if dir := filepath.Dir(logPath); dir != "." {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not create log directory %s: %v\n", dir, err)
+			}
 		}
 
 		logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: could not open log file %s: %v\n", logPath, err)
+			fmt.Fprintf(os.Stderr, "ERROR: could not open log file %s: %v\n", logPath, err)
+			fmt.Fprintf(os.Stderr, "Logs will be written to stderr instead.\n")
 			logFile = os.Stderr
 		} else {
 			defer logFile.Close()
@@ -69,7 +91,7 @@ func main() {
 	} else {
 		// Disabled: set a no-op logger that discards everything.
 		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError + 1})))
-		fmt.Println("Logging disabled (log_level is empty)")
+		fmt.Println("Logging disabled (set log_level in config.json to enable)")
 	}
 
 	slog.Info("GhostType starting",


### PR DESCRIPTION
## Summary
- **Fix**: Log file path now resolved relative to the **config file directory** (not the executable directory). This was the root cause — when config falls back to CWD but the exe is elsewhere, the log file was created in an unexpected location the user couldn't find.
- **Fix**: Create parent directories for log file path (like the POC does with `os.MkdirAll`)
- **Fix**: Normalize `log_level` to lowercase — `"Debug"`, `"DEBUG"`, `"debug"` all work now
- **Fix**: Validate `log_level` values — typos like `"verbose"` now produce a clear error instead of silently defaulting
- **Improvement**: Config path resolved to absolute and printed, so the user always knows which config is loaded
- **Improvement**: Clearer error messages when log file can't be created
- Bumps version to `v0.1.13`

Addresses #39

## Test plan
- [x] All 40 tests pass (`go test ./...`)
- [x] New test: `TestLoadLogLevelCaseInsensitive` — verifies `"DEBUG"` normalizes to `"debug"`
- [x] New test: `TestLoadInvalidLogLevel` — verifies `"verbose"` produces validation error
- [ ] Manual: compile on Windows, set `"log_level": "debug"` in config.json, verify `ghosttype.log` appears in same directory as config
- [ ] Manual: verify console output shows absolute paths for config and log files

🤖 Generated with [Claude Code](https://claude.com/claude-code)