### PR TITLE
Smart text selection detection

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -30,6 +30,57 @@ func winBeep(freq, durationMs uint32) {
 	procBeep.Call(uintptr(freq), uintptr(durationMs))
 }
 
+// captureText detects whether the user has an active text selection. It clears
+// the clipboard, copies, and checks. If text was copied the user had a selection.
+// Otherwise it falls back to select-all + copy.
+// Returns the captured text, whether the user had an active selection, and any error.
+func captureText(
+	modeName string,
+	cb *clipboard.Clipboard,
+	kb *keyboard.WindowsSimulator,
+) (text string, hadSelection bool, err error) {
+	// Clear clipboard so we can detect whether Ctrl+C actually grabbed something.
+	if err := cb.Clear(); err != nil {
+		return "", false, fmt.Errorf("clear clipboard: %w", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Try copying the current selection (if any).
+	if err := kb.Copy(); err != nil {
+		return "", false, fmt.Errorf("copy: %w", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	text, err = cb.Read()
+	if err != nil {
+		return "", false, fmt.Errorf("read clipboard: %w", err)
+	}
+
+	if text != "" {
+		slog.Info("Selection detected", "mode", modeName, "len", len(text))
+		return text, true, nil
+	}
+
+	// No selection — fall back to select-all + copy.
+	slog.Debug("No selection detected, falling back to select-all", "mode", modeName)
+	if err := kb.SelectAll(); err != nil {
+		return "", false, fmt.Errorf("select all: %w", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if err := kb.Copy(); err != nil {
+		return "", false, fmt.Errorf("copy after select-all: %w", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	text, err = cb.Read()
+	if err != nil {
+		return "", false, fmt.Errorf("read clipboard after select-all: %w", err)
+	}
+
+	return text, false, nil
+}
+
 // processMode captures text from the active window, sends it through the LLM
 // with the given mode, and pastes the result back. This is the shared workflow
 // for correction, translation, and rewrite hotkeys.
@@ -52,25 +103,10 @@ func processMode(
 		return
 	}
 
-	// Select all + copy.
-	if err := kb.SelectAll(); err != nil {
-		slog.Error("SelectAll failed", "mode", modeName, "error", err)
-		cb.Restore()
-		return
-	}
-	time.Sleep(50 * time.Millisecond)
-
-	if err := kb.Copy(); err != nil {
-		slog.Error("Copy failed", "mode", modeName, "error", err)
-		cb.Restore()
-		return
-	}
-	time.Sleep(100 * time.Millisecond)
-
-	// Read captured text.
-	text, err := cb.Read()
+	// Capture text — detects existing selection or falls back to select-all.
+	text, hadSelection, err := captureText(modeName, cb, kb)
 	if err != nil {
-		slog.Error("Failed to read clipboard", "mode", modeName, "error", err)
+		slog.Error("Failed to capture text", "mode", modeName, "error", err)
 		cb.Restore()
 		return
 	}
@@ -80,7 +116,7 @@ func processMode(
 		return
 	}
 
-	slog.Info("Captured text", "mode", modeName, "len", len(text), "text", text)
+	slog.Info("Captured text", "mode", modeName, "len", len(text), "selection", hadSelection, "text", text)
 	fmt.Printf("[%s] Captured: %q\n", modeName, text)
 
 	// Create cancellable context with timeout.
@@ -106,19 +142,24 @@ func processMode(
 		return
 	}
 
-	// Write result, select all, paste.
+	// Write result to clipboard.
 	if err := cb.Write(result); err != nil {
 		slog.Error("Failed to write result to clipboard", "mode", modeName, "error", err)
 		cb.Restore()
 		return
 	}
 
-	if err := kb.SelectAll(); err != nil {
-		slog.Error("SelectAll (paste prep) failed", "mode", modeName, "error", err)
-		cb.Restore()
-		return
+	// Paste-prep: only select-all before paste when we used select-all to capture.
+	// If the user had a selection, it's still active after Ctrl+C — Ctrl+V replaces it.
+	// If we did select-all, re-do it in case the user clicked during the LLM call.
+	if !hadSelection {
+		if err := kb.SelectAll(); err != nil {
+			slog.Error("SelectAll (paste prep) failed", "mode", modeName, "error", err)
+			cb.Restore()
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
-	time.Sleep(50 * time.Millisecond)
 
 	if err := kb.Paste(); err != nil {
 		slog.Error("Paste failed", "mode", modeName, "error", err)

--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -13,6 +13,7 @@ type Clipboard struct {
 	// read and write functions are injectable for testing and platform abstraction
 	readFn  func() (string, error)
 	writeFn func(text string) error
+	clearFn func() error
 }
 
 // New creates a new Clipboard with the given platform-specific read/write functions.
@@ -21,6 +22,27 @@ func New(readFn func() (string, error), writeFn func(text string) error) *Clipbo
 		readFn:  readFn,
 		writeFn: writeFn,
 	}
+}
+
+// WithClear sets a platform-specific clear function and returns the Clipboard
+// for chaining. If not set, Clear() falls back to writing an empty string.
+func (c *Clipboard) WithClear(fn func() error) *Clipboard {
+	c.clearFn = fn
+	return c
+}
+
+// Clear empties the clipboard. Uses the platform-specific clearFn if available,
+// otherwise falls back to writing an empty string.
+func (c *Clipboard) Clear() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.clearFn != nil {
+		return c.clearFn()
+	}
+	if c.writeFn != nil {
+		return c.writeFn("")
+	}
+	return fmt.Errorf("clipboard clear not available: no clear or write function set")
 }
 
 // Read returns the current clipboard text content.

--- a/clipboard/clipboard_test.go
+++ b/clipboard/clipboard_test.go
@@ -112,3 +112,67 @@ func TestClipboard_WriteError(t *testing.T) {
 		t.Fatal("expected write error")
 	}
 }
+
+func TestClipboard_Clear(t *testing.T) {
+	var store string
+	cb := New(
+		func() (string, error) { return store, nil },
+		func(text string) error { store = text; return nil },
+	)
+
+	// Write something, then clear, verify read returns ""
+	if err := cb.Write("hello"); err != nil {
+		t.Fatalf("unexpected write error: %v", err)
+	}
+	if err := cb.Clear(); err != nil {
+		t.Fatalf("unexpected clear error: %v", err)
+	}
+	got, err := cb.Read()
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string after clear, got %q", got)
+	}
+}
+
+func TestClipboard_ClearFallback(t *testing.T) {
+	var store string = "content"
+	cb := New(
+		func() (string, error) { return store, nil },
+		func(text string) error { store = text; return nil },
+	)
+	// No clearFn set — should fall back to writeFn("")
+	if err := cb.Clear(); err != nil {
+		t.Fatalf("unexpected clear error: %v", err)
+	}
+	if store != "" {
+		t.Errorf("expected store to be empty after fallback clear, got %q", store)
+	}
+}
+
+func TestClipboard_ClearWithCustomFn(t *testing.T) {
+	called := false
+	cb := New(
+		func() (string, error) { return "", nil },
+		func(text string) error { return nil },
+	).WithClear(func() error {
+		called = true
+		return nil
+	})
+
+	if err := cb.Clear(); err != nil {
+		t.Fatalf("unexpected clear error: %v", err)
+	}
+	if !called {
+		t.Error("expected custom clearFn to be called")
+	}
+}
+
+func TestClipboard_ClearNilFunctions(t *testing.T) {
+	cb := New(nil, nil)
+	err := cb.Clear()
+	if err == nil {
+		t.Fatal("expected error when both clearFn and writeFn are nil")
+	}
+}

--- a/clipboard/clipboard_windows.go
+++ b/clipboard/clipboard_windows.go
@@ -28,7 +28,21 @@ const (
 
 // NewWindowsClipboard creates a Clipboard using native Windows clipboard API.
 func NewWindowsClipboard() *Clipboard {
-	return New(windowsRead, windowsWrite)
+	return New(windowsRead, windowsWrite).WithClear(windowsClear)
+}
+
+func windowsClear() error {
+	ret, _, _ := procOpenClipboard.Call(0)
+	if ret == 0 {
+		return fmt.Errorf("failed to open clipboard")
+	}
+	defer procCloseClipboard.Call()
+
+	ret, _, _ = procEmptyClipboard.Call()
+	if ret == 0 {
+		return fmt.Errorf("failed to empty clipboard")
+	}
+	return nil
 }
 
 func windowsRead() (string, error) {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.13"
+const Version = "0.1.14"


### PR DESCRIPTION
## Summary
- Detect existing text selection before capturing: if user selected text, process only that; otherwise fall back to select-all
- Add `Clear()` method to clipboard package with native Windows `EmptyClipboard` syscall
- Extract `captureText()` helper with selection-probe logic (clear → copy → check → fallback)
- Conditional paste-prep: skip `Ctrl+A` before paste when user had a selection

Resolves #42

## Test plan
- [ ] Notepad: select one sentence → Ctrl+G → only that sentence corrected
- [ ] Notepad: no selection → Ctrl+G → entire text corrected (select-all fallback)
- [ ] Repeat for Ctrl+J (translate) and F9 (rewrite)
- [ ] Ctrl+Z undo works after both scenarios
- [ ] Empty text field → hotkey → no action, logs warning
- [ ] Clipboard content preserved after processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)