### PR TITLE
Simplify to single Ctrl+G action hotkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 GhostType is a lightweight background service that hooks into your chat application (primarily Firestorm Second Life viewer) and provides real-time spelling correction, language translation, and creative text rewriting — powered by your choice of LLM provider.
 
-Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, corrected too. Need to translate? **F7**. Want to change the target language? **Ctrl+F7** — a tiny floating label near your cursor shows "To French" or "To English". Want a funny reply? **F8**. Want to switch rewrite style? **Ctrl+F8** — a floating label shows "Funny", "Professional", etc. Undo with **Ctrl+Z** or cancel with **Escape**. That simple.
+Type in French, hit **Ctrl+G**, get it corrected. Switch to English, hit **Ctrl+G**, corrected too. Want to translate or rewrite instead? Change the active mode in the system tray (or `config.json`) — **Ctrl+G** always does whatever mode is active. Undo with **Ctrl+Z** or cancel with **Escape**. That simple.
 
 ---
 
@@ -34,7 +34,7 @@ Type in French, hit **F6**, get it corrected. Switch to English, hit **F6**, cor
 - **Translate** — Instantly translates between French and English (or any configured language pair)
 - **Rewrite** — Rewrites your text using customizable prompt templates (funny, formal, sarcastic, flirty, poetic, and more)
 - **Multi-Provider** — Works with Anthropic Claude, OpenAI GPT, Google Gemini, xAI Grok, or local Ollama models
-- **Hotkey Driven** — F6 to correct, F7 to translate, F8 to rewrite, Ctrl+F7 to toggle translation language, Ctrl+F8 to cycle rewrite templates, Escape to cancel
+- **Hotkey Driven** — One hotkey to learn: Ctrl+G performs the active mode (correct, translate, or rewrite). Escape to cancel. Optional dedicated hotkeys for power users
 - **Configurable** — JSON config file for API keys, providers, hotkeys, prompts, overlay settings, and custom rewrite templates
 - **Lightweight** — Single binary, runs in the background, under 50 MB memory, near-zero CPU at idle
 - **Cross-Platform** — Windows first, Linux and macOS coming in future releases
@@ -71,17 +71,26 @@ GhostType starts minimized in your system tray. Open Firestorm, type something i
 
 ## Hotkeys
 
+### Default
+
 | Hotkey | Action |
 |--------|--------|
-| **F6** | Correct spelling, grammar, and syntax |
-| **Ctrl+F7** | Toggle translation target language (shows cursor notification) |
-| **F7** | Translate to selected target language |
-| **Ctrl+F8** | Toggle rewrite template (shows cursor notification) |
-| **F8** | Rewrite using selected template |
+| **Ctrl+G** | Perform active mode (correct, translate, or rewrite) |
 | **Escape** | Cancel in-progress operation |
 | **Ctrl+Z** | Undo replacement (native) |
 
-All hotkeys are configurable in `config.json`.
+### Optional (add in `config.json`)
+
+Power users can add dedicated hotkeys for specific modes:
+
+| Config Key | Example | Action |
+|------------|---------|--------|
+| `hotkeys.translate` | `"Ctrl+J"` | Translate directly |
+| `hotkeys.toggle_language` | `"Ctrl+F8"` | Cycle translation target language |
+| `hotkeys.rewrite` | `"F9"` | Rewrite directly |
+| `hotkeys.cycle_template` | `"Ctrl+F9"` | Cycle rewrite template |
+
+All hotkeys are configurable in `config.json`. Set `active_mode` to `"correct"`, `"translate"`, or `"rewrite"` to choose what **Ctrl+G** does.
 
 ---
 
@@ -101,13 +110,14 @@ GhostType is configured entirely through `config.json`. Here is a full example:
     "fr": "French"
   },
   "default_translate_target": "en",
+  "active_mode": "correct",
   "hotkeys": {
-    "correct": "F6",
-    "translate": "F7",
-    "toggle_language": "Ctrl+F7",
-    "rewrite": "F8",
-    "cycle_template": "Ctrl+F8",
-    "cancel": "Escape"
+    "correct": "Ctrl+G",
+    "cancel": "Escape",
+    "translate": "",
+    "toggle_language": "",
+    "rewrite": "",
+    "cycle_template": ""
   },
   "prompts": {
     "correct": "Detect the language. Fix spelling and grammar. Return ONLY corrected text.",
@@ -194,12 +204,11 @@ go test ./...
 
 1. GhostType runs in the background and watches for hotkey presses.
 2. It works globally — hotkeys fire regardless of which window is focused.
-3. Before translating, you can press **Ctrl+F7** to toggle the translation target language. A brief floating label appears near your cursor showing the new target (e.g., "To French"). Before rewriting, you can press **Ctrl+F8** to toggle the rewrite template. A floating label appears showing the template name (e.g., "Funny", "Professional").
-4. When you press an action hotkey (**F6**, **F7**, or **F8**), GhostType selects all text in the active chat input, copies it to clipboard, and reads it.
-5. The text is sent to your configured LLM provider with the appropriate prompt.
-6. The corrected/translated/rewritten result appears in an overlay near the chat input.
-7. The result auto-replaces your text. Press **Escape** to cancel, or **Ctrl+Z** to undo.
-8. Your original clipboard content is preserved and restored.
+3. Choose your active mode: **correct**, **translate**, or **rewrite** (via `active_mode` in config, or system tray in a future update).
+4. When you press **Ctrl+G**, GhostType detects any selected text. If you have a selection, only that text is processed. If nothing is selected, it selects all text in the active input.
+5. The text is sent to your configured LLM provider with the appropriate prompt for the active mode.
+6. The result replaces the original text. Press **Escape** to cancel, or **Ctrl+Z** to undo.
+7. Your original clipboard content is preserved and restored.
 
 ---
 

--- a/app_windows.go
+++ b/app_windows.go
@@ -176,6 +176,18 @@ func processMode(
 	fmt.Printf("[%s] Result: %q\n", modeName, result)
 }
 
+// modeFromString converts a mode name string to a mode.Mode value.
+func modeFromString(name string) (mode.Mode, string) {
+	switch name {
+	case "translate":
+		return mode.ModeTranslate, "Translation"
+	case "rewrite":
+		return mode.ModeRewrite, "Rewrite"
+	default:
+		return mode.ModeCorrect, "Correction"
+	}
+}
+
 func runApp(cfg *config.Config, router *mode.Router) {
 	// Windows RegisterHotKey and GetMessageW must run on the same OS thread.
 	runtime.LockOSThread()
@@ -188,60 +200,86 @@ func runApp(cfg *config.Config, router *mode.Router) {
 	var mu sync.Mutex
 	var cancelLLM context.CancelFunc
 
-	// Register correction hotkey.
-	err := hk.Register("correct", cfg.Hotkeys.Correct, func() {
-		processMode("Correction", mode.ModeCorrect, cfg, router, cb, kb, &mu, &cancelLLM)
+	// Active mode state — determines what the action hotkey (Ctrl+G) does.
+	// Protected by mu. Can be changed at runtime (e.g., from tray menu).
+	activeMode := cfg.ActiveMode
+
+	// SetActiveMode changes the active mode at runtime.
+	// Exported for future use by tray menu (#56).
+	setActiveMode := func(modeName string) {
+		mu.Lock()
+		activeMode = modeName
+		mu.Unlock()
+		slog.Info("Active mode changed", "mode", modeName)
+		fmt.Printf("Active mode: %s\n", modeName)
+		winBeep(600, 80)
+	}
+	_ = setActiveMode // will be used by tray menu in #56
+
+	// Register main action hotkey — dispatches based on active mode.
+	err := hk.Register("action", cfg.Hotkeys.Correct, func() {
+		mu.Lock()
+		currentMode := activeMode
+		mu.Unlock()
+
+		m, displayName := modeFromString(currentMode)
+		processMode(displayName, m, cfg, router, cb, kb, &mu, &cancelLLM)
 	})
 	if err != nil {
-		slog.Error("Failed to register correction hotkey", "key", cfg.Hotkeys.Correct, "error", err)
+		slog.Error("Failed to register action hotkey", "key", cfg.Hotkeys.Correct, "error", err)
 		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Correct, err)
 		return
 	}
 
-	// Register translation hotkey.
-	err = hk.Register("translate", cfg.Hotkeys.Translate, func() {
-		processMode("Translation", mode.ModeTranslate, cfg, router, cb, kb, &mu, &cancelLLM)
-	})
-	if err != nil {
-		slog.Error("Failed to register translate hotkey", "key", cfg.Hotkeys.Translate, "error", err)
-		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Translate, err)
-		return
+	// Register optional dedicated hotkeys (only if configured).
+	if cfg.Hotkeys.Translate != "" {
+		err = hk.Register("translate", cfg.Hotkeys.Translate, func() {
+			processMode("Translation", mode.ModeTranslate, cfg, router, cb, kb, &mu, &cancelLLM)
+		})
+		if err != nil {
+			slog.Error("Failed to register translate hotkey", "key", cfg.Hotkeys.Translate, "error", err)
+			fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Translate, err)
+			return
+		}
 	}
 
-	// Register toggle-language hotkey — cycles translation target, no LLM call.
-	err = hk.Register("toggle_language", cfg.Hotkeys.ToggleLanguage, func() {
-		name := router.ToggleTranslateTarget()
-		slog.Info("Translation target toggled", "target", name)
-		fmt.Printf("Translation target: %s\n", name)
-		winBeep(600, 80)
-	})
-	if err != nil {
-		slog.Error("Failed to register toggle-language hotkey", "key", cfg.Hotkeys.ToggleLanguage, "error", err)
-		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.ToggleLanguage, err)
-		return
+	if cfg.Hotkeys.ToggleLanguage != "" {
+		err = hk.Register("toggle_language", cfg.Hotkeys.ToggleLanguage, func() {
+			name := router.ToggleTranslateTarget()
+			slog.Info("Translation target toggled", "target", name)
+			fmt.Printf("Translation target: %s\n", name)
+			winBeep(600, 80)
+		})
+		if err != nil {
+			slog.Error("Failed to register toggle-language hotkey", "key", cfg.Hotkeys.ToggleLanguage, "error", err)
+			fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.ToggleLanguage, err)
+			return
+		}
 	}
 
-	// Register rewrite hotkey.
-	err = hk.Register("rewrite", cfg.Hotkeys.Rewrite, func() {
-		processMode("Rewrite", mode.ModeRewrite, cfg, router, cb, kb, &mu, &cancelLLM)
-	})
-	if err != nil {
-		slog.Error("Failed to register rewrite hotkey", "key", cfg.Hotkeys.Rewrite, "error", err)
-		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Rewrite, err)
-		return
+	if cfg.Hotkeys.Rewrite != "" {
+		err = hk.Register("rewrite", cfg.Hotkeys.Rewrite, func() {
+			processMode("Rewrite", mode.ModeRewrite, cfg, router, cb, kb, &mu, &cancelLLM)
+		})
+		if err != nil {
+			slog.Error("Failed to register rewrite hotkey", "key", cfg.Hotkeys.Rewrite, "error", err)
+			fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.Rewrite, err)
+			return
+		}
 	}
 
-	// Register cycle-template hotkey — cycles rewrite template, no LLM call.
-	err = hk.Register("cycle_template", cfg.Hotkeys.CycleTemplate, func() {
-		name := router.CycleTemplate()
-		slog.Info("Rewrite template cycled", "template", name)
-		fmt.Printf("Rewrite template: %s\n", name)
-		winBeep(600, 80)
-	})
-	if err != nil {
-		slog.Error("Failed to register cycle-template hotkey", "key", cfg.Hotkeys.CycleTemplate, "error", err)
-		fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.CycleTemplate, err)
-		return
+	if cfg.Hotkeys.CycleTemplate != "" {
+		err = hk.Register("cycle_template", cfg.Hotkeys.CycleTemplate, func() {
+			name := router.CycleTemplate()
+			slog.Info("Rewrite template cycled", "template", name)
+			fmt.Printf("Rewrite template: %s\n", name)
+			winBeep(600, 80)
+		})
+		if err != nil {
+			slog.Error("Failed to register cycle-template hotkey", "key", cfg.Hotkeys.CycleTemplate, "error", err)
+			fmt.Fprintf(os.Stderr, "Error: failed to register hotkey %s: %v\n", cfg.Hotkeys.CycleTemplate, err)
+			return
+		}
 	}
 
 	// Register cancel hotkey — cancels in-progress LLM call, does NOT exit.

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	Languages              []string          `json:"languages"`
 	LanguageNames          map[string]string `json:"language_names"`
 	DefaultTranslateTarget string            `json:"default_translate_target"`
+	ActiveMode             string            `json:"active_mode"`
 	Hotkeys                Hotkeys           `json:"hotkeys"`
 	Prompts                Prompts           `json:"prompts"`
 	Overlay                Overlay           `json:"overlay"`
@@ -75,12 +76,13 @@ func DefaultConfig() Config {
 			"fr": "French",
 		},
 		DefaultTranslateTarget: "en",
+		ActiveMode:             "correct",
 		Hotkeys: Hotkeys{
 			Correct:        "Ctrl+G",
-			Translate:      "Ctrl+J",
-			ToggleLanguage: "Ctrl+F8",
-			Rewrite:        "F9",
-			CycleTemplate:  "Ctrl+F9",
+			Translate:      "",
+			ToggleLanguage: "",
+			Rewrite:        "",
+			CycleTemplate:  "",
 			Cancel:         "Escape",
 		},
 		Prompts: Prompts{
@@ -168,21 +170,14 @@ func applyDefaults(cfg *Config) {
 	if cfg.LogLevel != "" && cfg.LogFile == "" {
 		cfg.LogFile = "ghosttype.log"
 	}
+	if cfg.ActiveMode == "" {
+		cfg.ActiveMode = "correct"
+	}
 	if cfg.Hotkeys.Correct == "" {
 		cfg.Hotkeys.Correct = "Ctrl+G"
 	}
-	if cfg.Hotkeys.Translate == "" {
-		cfg.Hotkeys.Translate = "Ctrl+J"
-	}
-	if cfg.Hotkeys.ToggleLanguage == "" {
-		cfg.Hotkeys.ToggleLanguage = "Ctrl+F8"
-	}
-	if cfg.Hotkeys.Rewrite == "" {
-		cfg.Hotkeys.Rewrite = "F9"
-	}
-	if cfg.Hotkeys.CycleTemplate == "" {
-		cfg.Hotkeys.CycleTemplate = "Ctrl+F9"
-	}
+	// Translate, ToggleLanguage, Rewrite, CycleTemplate default to empty
+	// (not registered). Users can add dedicated hotkeys in config if desired.
 	if cfg.Hotkeys.Cancel == "" {
 		cfg.Hotkeys.Cancel = "Escape"
 	}
@@ -222,6 +217,15 @@ func validate(cfg *Config) error {
 
 	if cfg.Prompts.Correct == "" {
 		return fmt.Errorf("prompts.correct is required")
+	}
+
+	validModes := map[string]bool{
+		"correct":   true,
+		"translate": true,
+		"rewrite":   true,
+	}
+	if !validModes[cfg.ActiveMode] {
+		return fmt.Errorf("unsupported active_mode: %q (valid: correct, translate, rewrite)", cfg.ActiveMode)
 	}
 
 	// Validate log_level if set.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,14 +22,20 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.TimeoutMs != 5000 {
 		t.Errorf("expected default timeout_ms 5000, got %d", cfg.TimeoutMs)
 	}
+	if cfg.ActiveMode != "correct" {
+		t.Errorf("expected default active_mode 'correct', got '%s'", cfg.ActiveMode)
+	}
 	if cfg.Hotkeys.Correct != "Ctrl+G" {
 		t.Errorf("expected default correct hotkey 'Ctrl+G', got '%s'", cfg.Hotkeys.Correct)
 	}
-	if cfg.Hotkeys.Translate != "Ctrl+J" {
-		t.Errorf("expected default translate hotkey 'Ctrl+J', got '%s'", cfg.Hotkeys.Translate)
+	if cfg.Hotkeys.Translate != "" {
+		t.Errorf("expected default translate hotkey empty, got '%s'", cfg.Hotkeys.Translate)
 	}
-	if cfg.Hotkeys.Rewrite != "F9" {
-		t.Errorf("expected default rewrite hotkey 'F9', got '%s'", cfg.Hotkeys.Rewrite)
+	if cfg.Hotkeys.Rewrite != "" {
+		t.Errorf("expected default rewrite hotkey empty, got '%s'", cfg.Hotkeys.Rewrite)
+	}
+	if cfg.Hotkeys.Cancel != "Escape" {
+		t.Errorf("expected default cancel hotkey 'Escape', got '%s'", cfg.Hotkeys.Cancel)
 	}
 	if len(cfg.Languages) != 2 {
 		t.Errorf("expected 2 default languages, got %d", len(cfg.Languages))
@@ -300,6 +306,113 @@ func TestLoadInvalidLogLevel(t *testing.T) {
 	_, err := Load(path)
 	if err == nil {
 		t.Fatal("expected validation error for invalid log_level")
+	}
+}
+
+func TestLoadActiveModeDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.ActiveMode != "correct" {
+		t.Errorf("expected default active_mode 'correct', got '%s'", loaded.ActiveMode)
+	}
+}
+
+func TestLoadActiveModeCustom(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"active_mode":  "translate",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if loaded.ActiveMode != "translate" {
+		t.Errorf("expected active_mode 'translate', got '%s'", loaded.ActiveMode)
+	}
+}
+
+func TestLoadActiveModeInvalid(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"active_mode":  "invalid",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected validation error for invalid active_mode")
+	}
+}
+
+func TestLoadOptionalHotkeysEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := map[string]interface{}{
+		"llm_provider": "openai",
+		"api_key":      "sk-test",
+		"model":        "gpt-4o",
+		"prompts":      map[string]interface{}{"correct": "Fix errors."},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	os.WriteFile(path, data, 0644)
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only action (correct) and cancel should have defaults
+	if loaded.Hotkeys.Correct != "Ctrl+G" {
+		t.Errorf("expected action hotkey 'Ctrl+G', got '%s'", loaded.Hotkeys.Correct)
+	}
+	if loaded.Hotkeys.Cancel != "Escape" {
+		t.Errorf("expected cancel hotkey 'Escape', got '%s'", loaded.Hotkeys.Cancel)
+	}
+	// Optional hotkeys should remain empty
+	if loaded.Hotkeys.Translate != "" {
+		t.Errorf("expected translate hotkey empty, got '%s'", loaded.Hotkeys.Translate)
+	}
+	if loaded.Hotkeys.Rewrite != "" {
+		t.Errorf("expected rewrite hotkey empty, got '%s'", loaded.Hotkeys.Rewrite)
+	}
+	if loaded.Hotkeys.ToggleLanguage != "" {
+		t.Errorf("expected toggle_language hotkey empty, got '%s'", loaded.Hotkeys.ToggleLanguage)
+	}
+	if loaded.Hotkeys.CycleTemplate != "" {
+		t.Errorf("expected cycle_template hotkey empty, got '%s'", loaded.Hotkeys.CycleTemplate)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.14"
+const Version = "0.1.15"

--- a/main.go
+++ b/main.go
@@ -114,22 +114,30 @@ func main() {
 	router := mode.NewRouter(cfg, client)
 
 	fmt.Println("")
-	fmt.Printf("Current translate target: %s\n", router.CurrentTranslateTarget())
-	fmt.Printf("Current rewrite template: %s\n", router.CurrentTemplateName())
+	fmt.Printf("Active mode: %s\n", cfg.ActiveMode)
+	fmt.Printf("Translate target: %s\n", router.CurrentTranslateTarget())
+	fmt.Printf("Rewrite template: %s\n", router.CurrentTemplateName())
 	fmt.Println("")
 	fmt.Println("Hotkeys:")
-	fmt.Printf("  %s - Correct spelling/grammar\n", cfg.Hotkeys.Correct)
-	fmt.Printf("  %s - Toggle translation language\n", cfg.Hotkeys.ToggleLanguage)
-	fmt.Printf("  %s - Translate\n", cfg.Hotkeys.Translate)
-	fmt.Printf("  %s - Cycle rewrite template\n", cfg.Hotkeys.CycleTemplate)
-	fmt.Printf("  %s - Rewrite\n", cfg.Hotkeys.Rewrite)
+	fmt.Printf("  %s - Action (%s)\n", cfg.Hotkeys.Correct, cfg.ActiveMode)
+	if cfg.Hotkeys.Translate != "" {
+		fmt.Printf("  %s - Translate\n", cfg.Hotkeys.Translate)
+	}
+	if cfg.Hotkeys.ToggleLanguage != "" {
+		fmt.Printf("  %s - Toggle translation language\n", cfg.Hotkeys.ToggleLanguage)
+	}
+	if cfg.Hotkeys.Rewrite != "" {
+		fmt.Printf("  %s - Rewrite\n", cfg.Hotkeys.Rewrite)
+	}
+	if cfg.Hotkeys.CycleTemplate != "" {
+		fmt.Printf("  %s - Cycle rewrite template\n", cfg.Hotkeys.CycleTemplate)
+	}
 	fmt.Printf("  %s - Cancel\n", cfg.Hotkeys.Cancel)
 	fmt.Println("")
 
 	slog.Info("GhostType ready",
-		"hotkey_correct", cfg.Hotkeys.Correct,
-		"hotkey_translate", cfg.Hotkeys.Translate,
-		"hotkey_rewrite", cfg.Hotkeys.Rewrite,
+		"active_mode", cfg.ActiveMode,
+		"hotkey_action", cfg.Hotkeys.Correct,
 	)
 
 	runApp(cfg, router)

--- a/mode/router.go
+++ b/mode/router.go
@@ -14,9 +14,9 @@ import (
 type Mode int
 
 const (
-	ModeCorrect   Mode = iota // F7 - spelling/grammar correction
-	ModeTranslate             // F8 - translation
-	ModeRewrite               // F9 - creative rewrite
+	ModeCorrect   Mode = iota // spelling/grammar correction
+	ModeTranslate             // translation
+	ModeRewrite               // creative rewrite
 )
 
 func (m Mode) String() string {


### PR DESCRIPTION
## Summary
- Replace 6 default hotkeys with 2: **Ctrl+G** (action) + **Escape** (cancel)
- Add `active_mode` config field to control what Ctrl+G does (correct/translate/rewrite)
- Optional dedicated hotkeys still supported when configured, just not registered by default
- Prepare `setActiveMode()` for future tray menu integration (#56)
- Update README with simplified hotkey docs, new config example, and updated How It Works

Resolves #55

## Test plan
- [ ] Default config: Ctrl+G corrects (active_mode defaults to "correct")
- [ ] `active_mode: "translate"` → Ctrl+G translates
- [ ] `active_mode: "rewrite"` → Ctrl+G rewrites
- [ ] Optional hotkeys (e.g. `"translate": "Ctrl+J"`) register when set
- [ ] Escape cancels in-progress LLM calls
- [ ] Invalid active_mode shows validation error
- [ ] `go test ./...` — all tests pass (4 new config tests)
- [ ] `GOOS=windows go build ./...` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)