### PR TITLE
Fix tray Exit deadlock — app never terminates

### DIFF
--- a/app_windows.go
+++ b/app_windows.go
@@ -261,10 +261,16 @@ func runApp(cfg *config.Config, router *mode.Router, configPath string) {
 			}
 		},
 		OnExit: func() {
+			slog.Info("Exit requested via tray menu")
+			fmt.Println("\nGhostType exiting (tray menu).")
 			hk.Stop()
-			if stopTrayFn != nil {
-				stopTrayFn()
-			}
+			// Do NOT call stopTrayFn() here — we are inside the tray's
+			// DispatchMessageW callback; the tray posts WM_DESTROY to
+			// itself after OnExit returns.
+			go func() {
+				time.Sleep(2 * time.Second)
+				os.Exit(0)
+			}()
 		},
 		GetActiveMode: func() string {
 			mu.Lock()
@@ -359,9 +365,13 @@ func runApp(cfg *config.Config, router *mode.Router, configPath string) {
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 		<-sigChan
 		fmt.Println("\nGhostType shutting down.")
-		slog.Info("GhostType shutting down")
+		slog.Info("GhostType shutting down (signal)")
 		stopTrayFn()
 		hk.Stop()
+		go func() {
+			time.Sleep(2 * time.Second)
+			os.Exit(0)
+		}()
 	}()
 
 	fmt.Println("GhostType is ready. Waiting for hotkey input...")

--- a/hotkey/hotkey_windows.go
+++ b/hotkey/hotkey_windows.go
@@ -12,10 +12,13 @@ import (
 )
 
 var (
-	user32              = syscall.NewLazyDLL("user32.dll")
-	procRegisterHotKey  = user32.NewProc("RegisterHotKey")
-	procUnregisterHotKey = user32.NewProc("UnregisterHotKey")
-	procGetMessage      = user32.NewProc("GetMessageW")
+	user32                = syscall.NewLazyDLL("user32.dll")
+	kernel32              = syscall.NewLazyDLL("kernel32.dll")
+	procRegisterHotKey    = user32.NewProc("RegisterHotKey")
+	procUnregisterHotKey  = user32.NewProc("UnregisterHotKey")
+	procGetMessage        = user32.NewProc("GetMessageW")
+	procPostThreadMessage = user32.NewProc("PostThreadMessageW")
+	procGetCurrentThreadID = kernel32.NewProc("GetCurrentThreadId")
 )
 
 // Virtual key codes for function keys and modifiers.
@@ -33,7 +36,10 @@ const (
 	vkF9     = 0x78
 )
 
-const wmHotkey = 0x0312
+const (
+	wmHotkey = 0x0312
+	wmQuit   = 0x0012
+)
 
 // msg represents a Windows MSG structure.
 type msg struct {
@@ -56,6 +62,8 @@ type WindowsManager struct {
 	hotkeys  map[string]registration
 	nextID   int
 	stopChan chan struct{}
+	stopOnce sync.Once
+	threadID uint32
 }
 
 // NewWindowsManager creates a new Windows hotkey manager.
@@ -141,7 +149,9 @@ func (m *WindowsManager) Unregister(name string) error {
 }
 
 func (m *WindowsManager) Listen() error {
-	slog.Debug("Entering message loop", "registered_hotkeys", len(m.hotkeys))
+	tid, _, _ := procGetCurrentThreadID.Call()
+	m.threadID = uint32(tid)
+	slog.Debug("Entering message loop", "registered_hotkeys", len(m.hotkeys), "threadID", m.threadID)
 	var message msg
 	for {
 		select {
@@ -182,5 +192,10 @@ func (m *WindowsManager) Listen() error {
 }
 
 func (m *WindowsManager) Stop() {
-	close(m.stopChan)
+	m.stopOnce.Do(func() {
+		close(m.stopChan)
+		if m.threadID != 0 {
+			procPostThreadMessage.Call(uintptr(m.threadID), uintptr(wmQuit), 0, 0)
+		}
+	})
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.1.21"
+const Version = "0.1.22"

--- a/tray/tray_windows.go
+++ b/tray/tray_windows.go
@@ -493,6 +493,9 @@ func (ts *trayState) handleMenuCommand(id int) {
 		if ts.cfg.OnExit != nil {
 			ts.cfg.OnExit()
 		}
+		// Post WM_DESTROY so the tray cleans itself up without OnExit
+		// needing to call the stop function (which would deadlock).
+		procPostMessageW.Call(ts.hwnd, wmDestroy, 0, 0)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #65.

- **hotkey/hotkey\_windows.go**: `Stop()` now uses `sync.Once` and posts `WM_QUIT` via `PostThreadMessageW` to wake up the blocked `GetMessageW` on the hotkey thread
- **tray/tray\_windows.go**: After calling `OnExit`, the tray posts `WM_DESTROY` to itself so the message loop exits cleanly without `OnExit` needing to call `stopTrayFn()`
- **app\_windows.go**: `OnExit` no longer calls `stopTrayFn()` (which deadlocked from inside `DispatchMessageW`); both exit paths (tray menu + signal) now have a 2-second `os.Exit(0)` safety net
- Bump version to v0.1.22

## Test plan

- [ ] Build: `GOOS=windows go build ./...` compiles cleanly
- [ ] Build: `go build ./...` (Linux) compiles cleanly
- [ ] Vet: `go vet ./...` — no issues
- [ ] Run on Windows — click Exit in tray menu — app terminates within 2 seconds
- [ ] Run on Windows — press Ctrl+C in console — app terminates within 2 seconds
- [ ] Run on Windows — verify hotkeys still work before exiting
- [ ] Verify no goroutine leak: app process disappears from Task Manager after exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)