### PR TITLE
core: HTTP API server, headless server, and CLI client (#284)

### DIFF
--- a/cmd/ghostspell-cli/main.go
+++ b/cmd/ghostspell-cli/main.go
@@ -1,0 +1,235 @@
+// Command ghostspell-cli is a CLI client for the GhostSpell API server.
+//
+// Usage:
+//
+//	ghostspell-cli process "teh quik brown fox"          # use default skill (Correct)
+//	ghostspell-cli process -skill 1 "make this polished" # use skill index 1 (Polish)
+//	ghostspell-cli transcribe recording.wav              # transcribe a WAV file
+//	ghostspell-cli prompts                               # list available prompts
+//	ghostspell-cli health                                # check server status
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+var serverURL string
+
+func main() {
+	flag.StringVar(&serverURL, "server", "http://127.0.0.1:7878", "GhostSpell API server URL")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	switch args[0] {
+	case "process":
+		cmdProcess(args[1:])
+	case "transcribe":
+		cmdTranscribe(args[1:])
+	case "prompts":
+		cmdPrompts()
+	case "health":
+		cmdHealth()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", args[0])
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: ghostspell-cli [-server URL] <command> [args]")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  process [-skill N] <text>   Process text through a skill")
+	fmt.Fprintln(os.Stderr, "  transcribe <file.wav>       Transcribe a WAV file")
+	fmt.Fprintln(os.Stderr, "  prompts                     List available prompts/skills")
+	fmt.Fprintln(os.Stderr, "  health                      Check server status")
+}
+
+func cmdProcess(args []string) {
+	fs := flag.NewFlagSet("process", flag.ExitOnError)
+	skill := fs.Int("skill", 0, "skill/prompt index (0 = Correct)")
+	timeout := fs.Int("timeout", 0, "timeout in seconds (0 = server default)")
+	fs.Parse(args)
+
+	text := strings.Join(fs.Args(), " ")
+	if text == "" {
+		// Try reading from stdin if no text argument.
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) == 0 {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading stdin: %v\n", err)
+				os.Exit(1)
+			}
+			text = string(data)
+		}
+	}
+	if text == "" {
+		fmt.Fprintln(os.Stderr, "Error: no text provided. Pass text as argument or pipe to stdin.")
+		os.Exit(1)
+	}
+
+	body := map[string]any{
+		"skill_index": *skill,
+		"text":        text,
+	}
+	url := serverURL + "/api/process"
+	if *timeout > 0 {
+		url += fmt.Sprintf("?timeout=%d", *timeout)
+	}
+
+	resp, err := postJSON(url, body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var result struct {
+		Text     string  `json:"text"`
+		Provider string  `json:"provider"`
+		Model    string  `json:"model"`
+		Duration float64 `json:"duration_seconds"`
+		Error    string  `json:"error"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error (%d): %s\n", resp.StatusCode, result.Error)
+		os.Exit(1)
+	}
+
+	fmt.Print(result.Text)
+	if !strings.HasSuffix(result.Text, "\n") {
+		fmt.Println()
+	}
+	fmt.Fprintf(os.Stderr, "[%s/%s in %.1fs]\n", result.Provider, result.Model, result.Duration)
+}
+
+func cmdTranscribe(args []string) {
+	fs := flag.NewFlagSet("transcribe", flag.ExitOnError)
+	language := fs.String("lang", "", "language code (e.g. 'en', 'fr') or empty for auto-detect")
+	fs.Parse(args)
+
+	if fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "Error: WAV file path required")
+		os.Exit(1)
+	}
+
+	wavPath := fs.Arg(0)
+	wavData, err := os.ReadFile(wavPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading %s: %v\n", wavPath, err)
+		os.Exit(1)
+	}
+
+	body := map[string]any{
+		"wav_data": base64.StdEncoding.EncodeToString(wavData),
+		"language": *language,
+	}
+
+	resp, err := postJSON(serverURL+"/api/transcribe", body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	var result struct {
+		Text  string `json:"text"`
+		Error string `json:"error"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error (%d): %s\n", resp.StatusCode, result.Error)
+		os.Exit(1)
+	}
+
+	fmt.Println(result.Text)
+}
+
+func cmdPrompts() {
+	resp, err := http.Get(serverURL + "/api/prompts")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Prompts []struct {
+			Index       int    `json:"index"`
+			Name        string `json:"name"`
+			Icon        string `json:"icon"`
+			Voice       bool   `json:"voice"`
+			Vision      bool   `json:"vision"`
+			DisplayMode string `json:"display_mode"`
+			Disabled    bool   `json:"disabled"`
+		} `json:"prompts"`
+		ActiveIndex int    `json:"active_index"`
+		Error       string `json:"error"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "Error (%d): %s\n", resp.StatusCode, result.Error)
+		os.Exit(1)
+	}
+
+	for _, p := range result.Prompts {
+		marker := "  "
+		if p.Index == result.ActiveIndex {
+			marker = "* "
+		}
+		flags := ""
+		if p.Voice {
+			flags += " [voice]"
+		}
+		if p.Vision {
+			flags += " [vision]"
+		}
+		if p.Disabled {
+			flags += " [disabled]"
+		}
+		fmt.Printf("%s%d. %s %s%s\n", marker, p.Index, p.Icon, p.Name, flags)
+	}
+}
+
+func cmdHealth() {
+	resp, err := http.Get(serverURL + "/api/health")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: cannot reach server at %s: %v\n", serverURL, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+	fmt.Printf("Status: %v\n", result["status"])
+	fmt.Printf("STT:    %v\n", result["has_stt"])
+}
+
+func postJSON(url string, body any) (*http.Response, error) {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{Timeout: 120 * time.Second}
+	return client.Post(url, "application/json", bytes.NewReader(data))
+}

--- a/cmd/ghostspell-server/main.go
+++ b/cmd/ghostspell-server/main.go
@@ -1,0 +1,136 @@
+// Command ghostspell-server runs GhostSpell as a headless HTTP API server.
+// No GUI, no tray, no hotkeys — pure core Engine exposed over HTTP.
+//
+// Usage:
+//
+//	ghostspell-server                       # default: 127.0.0.1:7878
+//	ghostspell-server -addr 127.0.0.1:9090  # custom port
+//	ghostspell-server -config /path/to/config.json
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/chrixbedardcad/GhostSpell/config"
+	"github.com/chrixbedardcad/GhostSpell/core"
+	"github.com/chrixbedardcad/GhostSpell/llm"
+	"github.com/chrixbedardcad/GhostSpell/mode"
+	"github.com/chrixbedardcad/GhostSpell/stt"
+	"github.com/chrixbedardcad/GhostSpell/stats"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:7878", "listen address (host:port)")
+	configPath := flag.String("config", "", "path to config.json (default: OS app data dir)")
+	flag.Parse()
+
+	// Resolve config path.
+	cfgPath := *configPath
+	if cfgPath == "" {
+		base, err := os.UserConfigDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: cannot determine config dir: %v\n", err)
+			os.Exit(1)
+		}
+		cfgPath = filepath.Join(base, "GhostSpell", "config.json")
+	}
+
+	// Load config.
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load config from %s: %v\n", cfgPath, err)
+		os.Exit(1)
+	}
+	fmt.Printf("GhostSpell Server — config: %s\n", cfgPath)
+
+	// Init LLM client + router.
+	var router *mode.Router
+	if cfg.DefaultModel != "" {
+		client, err := newClientFromConfig(cfg, cfg.DefaultModel)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: LLM init failed: %v\n", err)
+			slog.Warn("LLM init failed", "error", err)
+		} else {
+			router = mode.NewRouter(cfg, client)
+			fmt.Printf("LLM ready: %s\n", cfg.DefaultModel)
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "Warning: no default_model configured — /api/process will fail")
+	}
+
+	// Init STT (optional).
+	var transcriber stt.Transcriber
+	if cfg.Voice.Model != "" {
+		modelsDir, err := llm.LocalModelsDir()
+		if err == nil {
+			client, err := stt.NewGhostVoiceClient(cfg.Voice.Model, modelsDir, cfg.Voice.KeepAlive)
+			if err == nil {
+				transcriber = client
+				fmt.Printf("STT ready: %s\n", cfg.Voice.Model)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: STT init failed: %v\n", err)
+			}
+		}
+	}
+
+	// Init stats.
+	configDir := filepath.Dir(cfgPath)
+	st := stats.New(configDir)
+
+	// Create engine + API server.
+	engine := core.NewEngine(cfg, router, transcriber, st)
+	apiSrv := core.NewAPIServer(engine)
+
+	listenAddr, err := apiSrv.Start(*addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("API server listening on http://%s\n", listenAddr)
+	fmt.Println("Press Ctrl+C to stop.")
+
+	// Wait for shutdown signal.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+
+	fmt.Println("\nShutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	apiSrv.Shutdown(ctx)
+	fmt.Println("Bye.")
+}
+
+// newClientFromConfig builds an LLM client from config (same logic as main app).
+func newClientFromConfig(cfg *config.Config, label string) (llm.Client, error) {
+	model, ok := cfg.Models[label]
+	if !ok {
+		return nil, fmt.Errorf("model %q not found", label)
+	}
+	prov, ok := cfg.Providers[model.Provider]
+	if !ok {
+		return nil, fmt.Errorf("provider %q not configured", model.Provider)
+	}
+	def := config.LLMProviderDef{
+		Provider:    model.Provider,
+		APIKey:      prov.APIKey,
+		Model:       model.Model,
+		APIEndpoint: prov.APIEndpoint,
+		RefreshToken: prov.RefreshToken,
+		KeepAlive:   prov.KeepAlive,
+		TimeoutMs:   prov.TimeoutMs,
+		MaxTokens:   model.MaxTokens,
+	}
+	if model.TimeoutMs > 0 {
+		def.TimeoutMs = model.TimeoutMs
+	}
+	return llm.NewClientFromDef(def)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -127,6 +127,10 @@ type Config struct {
 
 	Voice VoiceConfig `json:"voice,omitempty"` // voice input settings (#236)
 
+	// API server settings (#284 Phase 2).
+	APIEnabled bool   `json:"api_enabled,omitempty"` // start HTTP API server alongside desktop app
+	APIAddr    string `json:"api_addr,omitempty"`     // listen address (default "127.0.0.1:7878")
+
 	LogLevel          string `json:"log_level"`
 	LogFile           string `json:"log_file"`
 	LastSeenVersion   string `json:"last_seen_version,omitempty"`

--- a/core/api.go
+++ b/core/api.go
@@ -1,0 +1,232 @@
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// APIServer serves GhostSpell's core Engine over HTTP.
+// All endpoints bind to localhost only — not exposed to the network.
+type APIServer struct {
+	engine *Engine
+	server *http.Server
+	addr   string // actual listen address after Start
+}
+
+// NewAPIServer creates a new API server backed by the given Engine.
+// It does not start listening — call Start() for that.
+func NewAPIServer(engine *Engine) *APIServer {
+	return &APIServer{engine: engine}
+}
+
+// Start begins listening on the given address (e.g. "127.0.0.1:7878").
+// Returns the actual address (useful when port is 0 for auto-assign).
+// Non-blocking — the server runs in a background goroutine.
+func (s *APIServer) Start(addr string) (string, error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/health", s.handleHealth)
+	mux.HandleFunc("GET /api/prompts", s.handlePrompts)
+	mux.HandleFunc("POST /api/process", s.handleProcess)
+	mux.HandleFunc("POST /api/transcribe", s.handleTranscribe)
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return "", fmt.Errorf("api: listen %s: %w", addr, err)
+	}
+	s.addr = ln.Addr().String()
+
+	s.server = &http.Server{
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 120 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	go func() {
+		slog.Info("[api] Server started", "addr", s.addr)
+		if err := s.server.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Error("[api] Server error", "error", err)
+		}
+	}()
+
+	return s.addr, nil
+}
+
+// Shutdown gracefully stops the API server.
+func (s *APIServer) Shutdown(ctx context.Context) error {
+	if s.server == nil {
+		return nil
+	}
+	slog.Info("[api] Server shutting down")
+	return s.server.Shutdown(ctx)
+}
+
+// Addr returns the address the server is listening on, or empty if not started.
+func (s *APIServer) Addr() string {
+	return s.addr
+}
+
+// --- Request/Response types ---
+
+// ProcessRequest is the JSON body for POST /api/process.
+type ProcessRequest struct {
+	SkillIndex int    `json:"skill_index"`
+	Text       string `json:"text"`
+}
+
+// ProcessResponse is the JSON response from POST /api/process.
+type ProcessResponse struct {
+	Text     string  `json:"text"`
+	Provider string  `json:"provider,omitempty"`
+	Model    string  `json:"model,omitempty"`
+	Duration float64 `json:"duration_seconds"`
+}
+
+// TranscribeRequest is the JSON body for POST /api/transcribe.
+type TranscribeRequest struct {
+	// WAVData is base64-encoded WAV audio.
+	WAVData  string `json:"wav_data"`
+	Language string `json:"language,omitempty"`
+}
+
+// TranscribeResponse is the JSON response from POST /api/transcribe.
+type TranscribeResponse struct {
+	Text string `json:"text"`
+}
+
+// PromptInfo describes a prompt for the GET /api/prompts response.
+type PromptInfo struct {
+	Index       int    `json:"index"`
+	Name        string `json:"name"`
+	Icon        string `json:"icon,omitempty"`
+	Voice       bool   `json:"voice,omitempty"`
+	Vision      bool   `json:"vision,omitempty"`
+	DisplayMode string `json:"display_mode,omitempty"`
+	Disabled    bool   `json:"disabled,omitempty"`
+}
+
+// ErrorResponse is the JSON error envelope.
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// --- Handlers ---
+
+func (s *APIServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":  "ok",
+		"has_stt": s.engine.HasSTT(),
+	})
+}
+
+func (s *APIServer) handlePrompts(w http.ResponseWriter, r *http.Request) {
+	cfg := s.engine.Config()
+	if cfg == nil {
+		writeError(w, http.StatusServiceUnavailable, "no config loaded")
+		return
+	}
+
+	prompts := make([]PromptInfo, len(cfg.Prompts))
+	for i, p := range cfg.Prompts {
+		prompts[i] = PromptInfo{
+			Index:       i,
+			Name:        p.Name,
+			Icon:        p.Icon,
+			Voice:       p.Voice,
+			Vision:      p.Vision,
+			DisplayMode: p.DisplayMode,
+			Disabled:    p.Disabled,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"prompts":      prompts,
+		"active_index": cfg.ActivePrompt,
+	})
+}
+
+func (s *APIServer) handleProcess(w http.ResponseWriter, r *http.Request) {
+	var req ProcessRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.Text == "" {
+		writeError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+
+	// Use timeout from query param or skill config.
+	timeout := s.engine.TimeoutForSkill(req.SkillIndex)
+	if tStr := r.URL.Query().Get("timeout"); tStr != "" {
+		if tSec, err := strconv.Atoi(tStr); err == nil && tSec > 0 {
+			timeout = time.Duration(tSec) * time.Second
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), timeout)
+	defer cancel()
+
+	result, err := s.engine.Process(ctx, req.SkillIndex, req.Text)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if ctx.Err() == context.DeadlineExceeded {
+			status = http.StatusGatewayTimeout
+		}
+		writeError(w, status, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ProcessResponse{
+		Text:     result.Text,
+		Provider: result.Provider,
+		Model:    result.Model,
+		Duration: result.Duration.Seconds(),
+	})
+}
+
+func (s *APIServer) handleTranscribe(w http.ResponseWriter, r *http.Request) {
+	var req TranscribeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.WAVData == "" {
+		writeError(w, http.StatusBadRequest, "wav_data is required")
+		return
+	}
+
+	wavBytes, err := base64.StdEncoding.DecodeString(req.WAVData)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "wav_data must be valid base64: "+err.Error())
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+
+	text, err := s.engine.Transcribe(ctx, wavBytes, req.Language)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(TranscribeResponse{Text: text})
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
+}

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -1,0 +1,282 @@
+package core
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chrixbedardcad/GhostSpell/config"
+	"github.com/chrixbedardcad/GhostSpell/llm"
+	"github.com/chrixbedardcad/GhostSpell/mode"
+)
+
+// testConfig returns a minimal config with prompts for API testing.
+func testConfig() *config.Config {
+	cfg := config.DefaultConfig()
+	return &cfg
+}
+
+// mockRouter wraps a mode.Router for testing. We can't easily mock
+// mode.Router, so we test error paths and use Engine's sentinel errors.
+
+func TestAPI_Health(t *testing.T) {
+	e := NewEngine(testConfig(), nil, &mockTranscriber{text: "hi"}, nil)
+	srv := NewAPIServer(e)
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealth(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["status"] != "ok" {
+		t.Fatalf("expected status=ok, got %v", resp["status"])
+	}
+	if resp["has_stt"] != true {
+		t.Fatalf("expected has_stt=true, got %v", resp["has_stt"])
+	}
+}
+
+func TestAPI_Health_NoSTT(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	req := httptest.NewRequest("GET", "/api/health", nil)
+	w := httptest.NewRecorder()
+	srv.handleHealth(w, req)
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["has_stt"] != false {
+		t.Fatalf("expected has_stt=false, got %v", resp["has_stt"])
+	}
+}
+
+func TestAPI_Prompts(t *testing.T) {
+	cfg := testConfig()
+	e := NewEngine(cfg, nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	req := httptest.NewRequest("GET", "/api/prompts", nil)
+	w := httptest.NewRecorder()
+	srv.handlePrompts(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Prompts     []PromptInfo `json:"prompts"`
+		ActiveIndex int          `json:"active_index"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if len(resp.Prompts) == 0 {
+		t.Fatal("expected prompts list to be non-empty")
+	}
+	if resp.Prompts[0].Name != "Correct" {
+		t.Fatalf("expected first prompt to be Correct, got %q", resp.Prompts[0].Name)
+	}
+}
+
+func TestAPI_Prompts_NoConfig(t *testing.T) {
+	e := NewEngine(nil, nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	req := httptest.NewRequest("GET", "/api/prompts", nil)
+	w := httptest.NewRecorder()
+	srv.handlePrompts(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
+
+func TestAPI_Process_NoRouter(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	body := `{"skill_index": 0, "text": "hello"}`
+	req := httptest.NewRequest("POST", "/api/process", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleProcess(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	var resp ErrorResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !strings.Contains(resp.Error, "no LLM router") {
+		t.Fatalf("expected router error, got %q", resp.Error)
+	}
+}
+
+func TestAPI_Process_EmptyText(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	body := `{"skill_index": 0, "text": ""}`
+	req := httptest.NewRequest("POST", "/api/process", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleProcess(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPI_Process_InvalidJSON(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	req := httptest.NewRequest("POST", "/api/process", strings.NewReader("{bad json"))
+	w := httptest.NewRecorder()
+	srv.handleProcess(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPI_Transcribe_NoSTT(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	wavB64 := base64.StdEncoding.EncodeToString([]byte("fake-wav"))
+	body := `{"wav_data": "` + wavB64 + `"}`
+	req := httptest.NewRequest("POST", "/api/transcribe", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTranscribe(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestAPI_Transcribe_Success(t *testing.T) {
+	e := NewEngine(testConfig(), nil, &mockTranscriber{text: "hello world"}, nil)
+	srv := NewAPIServer(e)
+
+	wavB64 := base64.StdEncoding.EncodeToString([]byte("fake-wav"))
+	body := `{"wav_data": "` + wavB64 + `", "language": "en"}`
+	req := httptest.NewRequest("POST", "/api/transcribe", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTranscribe(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp TranscribeResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Text != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", resp.Text)
+	}
+}
+
+func TestAPI_Transcribe_EmptyWAV(t *testing.T) {
+	e := NewEngine(testConfig(), nil, &mockTranscriber{text: "hi"}, nil)
+	srv := NewAPIServer(e)
+
+	body := `{"wav_data": ""}`
+	req := httptest.NewRequest("POST", "/api/transcribe", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTranscribe(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPI_Transcribe_InvalidBase64(t *testing.T) {
+	e := NewEngine(testConfig(), nil, &mockTranscriber{text: "hi"}, nil)
+	srv := NewAPIServer(e)
+
+	body := `{"wav_data": "not-valid-base64!!!"}`
+	req := httptest.NewRequest("POST", "/api/transcribe", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleTranscribe(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestAPI_StartAndShutdown(t *testing.T) {
+	e := NewEngine(testConfig(), nil, nil, nil)
+	srv := NewAPIServer(e)
+
+	addr, err := srv.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	if addr == "" {
+		t.Fatal("expected non-empty address")
+	}
+	if srv.Addr() != addr {
+		t.Fatalf("Addr() mismatch: %q vs %q", srv.Addr(), addr)
+	}
+
+	// Hit the health endpoint on the real server.
+	resp, err := http.Get("http://" + addr + "/api/health")
+	if err != nil {
+		t.Fatalf("GET /api/health failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+}
+
+// Verify that Process with a working router returns results.
+// We need a real Router for this — use a minimal mock LLM client.
+type mockLLMClient struct {
+	text string
+}
+
+func (m *mockLLMClient) Send(_ context.Context, req llm.Request) (*llm.Response, error) {
+	return &llm.Response{Text: m.text, Provider: "mock", Model: "mock-model"}, nil
+}
+
+func (m *mockLLMClient) Provider() string { return "mock" }
+func (m *mockLLMClient) Close()           {}
+
+func TestAPI_Process_Success(t *testing.T) {
+	cfg := testConfig()
+	cfg.DefaultModel = "test"
+	cfg.Models["test"] = config.ModelEntry{Provider: "mock", Model: "mock-model"}
+	cfg.Providers["mock"] = config.ProviderConfig{APIKey: "fake"}
+	router := mode.NewRouter(cfg, &mockLLMClient{text: "corrected text"})
+	e := NewEngine(cfg, router, nil, nil)
+	srv := NewAPIServer(e)
+
+	body := `{"skill_index": 0, "text": "teh quik brown fox"}`
+	req := httptest.NewRequest("POST", "/api/process", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handleProcess(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp ProcessResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Text != "corrected text" {
+		t.Fatalf("expected 'corrected text', got %q", resp.Text)
+	}
+	if resp.Provider != "mock" {
+		t.Fatalf("expected provider=mock, got %q", resp.Provider)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -303,6 +303,22 @@ func main() {
 	// Create the core engine — pure business logic, no UI dependencies.
 	appEngine = core.NewEngine(cfg, router, appSTT, appStats)
 
+	// Optionally start the HTTP API server for local integrations (#284).
+	if cfg.APIEnabled {
+		apiAddr := cfg.APIAddr
+		if apiAddr == "" {
+			apiAddr = "127.0.0.1:7878"
+		}
+		apiSrv := core.NewAPIServer(appEngine)
+		listenAddr, err := apiSrv.Start(apiAddr)
+		if err != nil {
+			slog.Error("API server failed to start", "addr", apiAddr, "error", err)
+			fmt.Fprintf(os.Stderr, "Warning: API server failed to start: %v\n", err)
+		} else {
+			fmt.Printf("API server: http://%s\n", listenAddr)
+		}
+	}
+
 	runApp(cfg, router, configPath, needsSetup, initError)
 }
 


### PR DESCRIPTION
## Summary
- **Phase 2 of #284** — expose core Engine over HTTP for headless / integration use
- `core/api.go`: HTTP API server with `/api/health`, `/api/prompts`, `/api/process`, `/api/transcribe`
- `cmd/ghostspell-server/`: standalone headless server (no GUI, no tray)
- `cmd/ghostspell-cli/`: CLI client for all API endpoints
- Desktop app optionally starts API server via `api_enabled` config flag

## Test plan
- [ ] `go test -race ./core/...` — all 20 tests pass (13 API + 7 engine)
- [ ] `go build ./cmd/ghostspell-server/` and `go build ./cmd/ghostspell-cli/` — compile clean
- [ ] Start server: `go run ./cmd/ghostspell-server/` — verify "API server listening on http://127.0.0.1:7878"
- [ ] Health check: `curl http://127.0.0.1:7878/api/health` — returns `{"status":"ok","has_stt":...}`
- [ ] List prompts: `go run ./cmd/ghostspell-cli/ prompts` — shows numbered prompt list
- [ ] Process text: `go run ./cmd/ghostspell-cli/ process "teh quik brown fox"` — returns corrected text (requires LLM provider configured)
- [ ] Process with skill: `go run ./cmd/ghostspell-cli/ process -skill 1 "make this better"` — uses skill index 1
- [ ] Pipe stdin: `echo "fix this txt" | go run ./cmd/ghostspell-cli/ process` — reads from stdin
- [ ] Transcribe: `go run ./cmd/ghostspell-cli/ transcribe test.wav` — returns transcription (requires STT model)
- [ ] Desktop API: set `"api_enabled": true` in config.json, launch desktop app — verify API server starts alongside GUI
- [ ] Error cases: empty text → 400, missing server → connection refused, bad JSON → 400, no STT → 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)