### PR TITLE
Fix #320 #323: Test button model mismatch, daemon errors, bug report empty config

### DIFF
--- a/gui/bugreport.go
+++ b/gui/bugreport.go
@@ -43,13 +43,23 @@ func (s *SettingsService) SubmitBugReport(description string) string {
 	sys := sysinfo.Collect()
 
 	// Build provider list (names only, no keys).
+	// Use cfgCopy if Settings is open; otherwise fall back to the live config
+	// (the tray menu's "Report a Bug..." calls this without opening Settings).
 	var providers []string
 	var defaultModel string
-	if s.cfgCopy != nil {
-		for name := range s.cfgCopy.Providers {
+	cfg := s.cfgCopy
+	if cfg == nil && s.liveCfg != nil {
+		if s.liveMu != nil {
+			s.liveMu.Lock()
+			defer s.liveMu.Unlock()
+		}
+		cfg = s.liveCfg
+	}
+	if cfg != nil {
+		for name := range cfg.Providers {
 			providers = append(providers, name)
 		}
-		defaultModel = s.cfgCopy.DefaultModel
+		defaultModel = cfg.DefaultModel
 	}
 
 	// Collect log tail.

--- a/gui/frontend/src/windows/Settings/GeneralTab.tsx
+++ b/gui/frontend/src/windows/Settings/GeneralTab.tsx
@@ -124,6 +124,10 @@ export function GeneralTab() {
   const [indicatorMode, setIndicatorMode] = useState("processing");
   const [hotkey, setHotkey] = useState("Ctrl+G");
 
+  // Active skill state
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [prompts, setPrompts] = useState<{ name: string; icon: string; disabled: boolean }[]>([]);
+
   // API server state
   const [apiEnabled, setApiEnabled] = useState(false);
   const [apiAddr, setApiAddr] = useState("127.0.0.1:7878");
@@ -159,6 +163,11 @@ export function GeneralTab() {
         setHotkey(platform === "darwin" ? hk.replace("Ctrl", "⌘") : hk);
         setApiEnabled(cfg.api_enabled ?? false);
         setApiAddr(cfg.api_addr || "127.0.0.1:7878");
+        // Active skill
+        setActiveIdx(cfg.active_prompt ?? 0);
+        setPrompts((cfg.prompts || []).map((p: { name: string; icon: string; disabled: boolean }) => ({
+          name: p.name, icon: p.icon, disabled: p.disabled,
+        })));
       } catch { /* ignore */ }
     });
     refreshAPIStatus();
@@ -175,11 +184,39 @@ export function GeneralTab() {
         <h2 className="text-[11px] font-semibold text-overlay-0 mb-4 uppercase tracking-widest">
           Activation
         </h2>
-        <div className="bg-surface-0/20 border border-surface-0/40 rounded-xl px-5 py-3.5 flex items-center gap-4">
-          <div className="px-3 py-1.5 rounded-lg bg-crust border border-surface-0 text-sm font-mono text-accent-blue">
-            {hotkey}
+        <div className="bg-surface-0/20 border border-surface-0/40 rounded-xl px-5 py-3.5 space-y-3">
+          <div className="flex items-center gap-4">
+            <div className="px-3 py-1.5 rounded-lg bg-crust border border-surface-0 text-sm font-mono text-accent-blue">
+              {hotkey}
+            </div>
+            <p className="text-xs text-overlay-0">Select text and press to activate</p>
           </div>
-          <p className="text-xs text-overlay-0">Select text and press to activate</p>
+
+          {prompts.length > 0 && (
+            <>
+              <div className="h-px bg-surface-0/50" />
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-[13px] font-semibold text-text">Active Skill</p>
+                  <p className="text-xs text-overlay-0 mt-0.5">The skill that runs when you press the hotkey</p>
+                </div>
+                <div className="w-52">
+                  <Dropdown
+                    value={String(activeIdx)}
+                    onChange={async (v) => {
+                      const idx = parseInt(v);
+                      setActiveIdx(idx);
+                      await goCall("setActivePromptFromIndicator", idx);
+                    }}
+                    options={prompts.map((p, i) => ({
+                      value: String(i),
+                      label: `${p.icon || "\uD83D\uDCDD"} ${p.name}${p.disabled ? " (disabled)" : ""}`,
+                    }))}
+                  />
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </section>
 

--- a/gui/service_config.go
+++ b/gui/service_config.go
@@ -479,8 +479,19 @@ func (s *SettingsService) TestProviderConnection(providerType string) string {
 		return "error: provider not found"
 	}
 
-	// Pick a default model for this provider type.
-	model := defaultTestModel(providerType)
+	// Prefer the user's actual saved model for this provider type.
+	// Fall back to a hardcoded default only if no model has been saved yet
+	// (e.g. during the wizard's setup page, before SaveModel has been called).
+	var model string
+	for _, me := range s.cfgCopy.Models {
+		if me.Provider == providerType && me.Model != "" {
+			model = me.Model
+			break
+		}
+	}
+	if model == "" {
+		model = defaultTestModel(providerType)
+	}
 	if model == "" {
 		return "error: no known test model for provider"
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.96.10.320"
+const Version = "0.96.11.323"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,4 +2,4 @@
 // Both the main app and the POC binary import this package.
 package version
 
-const Version = "0.96.9.319"
+const Version = "0.96.10.320"

--- a/llm/ghostai_client.go
+++ b/llm/ghostai_client.go
@@ -259,9 +259,13 @@ func (c *GhostAIClient) startDaemon(gpuEnabled bool) error {
 	scanner.Buffer(make([]byte, 256*1024), 256*1024)
 
 	if !scanner.Scan() {
+		// Daemon's stdout closed before sending a ready line. The process
+		// either failed to start, crashed immediately, or exited cleanly
+		// without writing. Capture exit code + stderr tail so this is
+		// diagnosable in user bug reports instead of a bare error string.
 		cmd.Process.Kill()
-		cmd.Wait()
-		return fmt.Errorf("ghost-ai: daemon did not send ready message")
+		waitErr := cmd.Wait()
+		return fmt.Errorf("ghost-ai: daemon did not send ready message%s", daemonFailureContext(waitErr))
 	}
 
 	readyLine := scanner.Text()
@@ -271,12 +275,12 @@ func (c *GhostAIClient) startDaemon(gpuEnabled bool) error {
 	}
 	if err := json.Unmarshal([]byte(readyLine), &ready); err != nil || !ready.Ready {
 		cmd.Process.Kill()
-		cmd.Wait()
+		waitErr := cmd.Wait()
 		errMsg := ready.Error
 		if errMsg == "" {
 			errMsg = "daemon failed to load model"
 		}
-		return fmt.Errorf("ghost-ai: %s", errMsg)
+		return fmt.Errorf("ghost-ai: %s%s", errMsg, daemonFailureContext(waitErr))
 	}
 
 	c.proc = cmd
@@ -362,6 +366,67 @@ func openGhostAILog() (*os.File, error) {
 	}
 	fmt.Fprintf(f, "\n=== ghostai %s started at %s ===\n", "daemon", time.Now().Format(time.RFC3339))
 	return f, nil
+}
+
+// ghostAILogPath returns the on-disk path for the ghostai stderr log.
+func ghostAILogPath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "GhostSpell", "ghostai.log")
+}
+
+// tailGhostAILog returns the last n bytes of ghostai.log, or "" if unreadable.
+// Used to surface stderr context when the daemon fails to start.
+func tailGhostAILog(n int64) string {
+	path := ghostAILogPath()
+	if path == "" {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	offset := int64(0)
+	if info.Size() > n {
+		offset = info.Size() - n
+	}
+	if _, err := f.Seek(offset, io.SeekStart); err != nil {
+		return ""
+	}
+	buf := make([]byte, info.Size()-offset)
+	rd, err := f.Read(buf)
+	if err != nil && err != io.EOF {
+		return ""
+	}
+	return strings.TrimSpace(string(buf[:rd]))
+}
+
+// daemonFailureContext builds a human-readable suffix describing why the
+// daemon process exited (exit code + tail of stderr log). Empty if there's
+// nothing useful to add.
+func daemonFailureContext(waitErr error) string {
+	var parts []string
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			parts = append(parts, fmt.Sprintf("exit %d", exitErr.ExitCode()))
+		} else {
+			parts = append(parts, waitErr.Error())
+		}
+	}
+	if tail := tailGhostAILog(2048); tail != "" {
+		parts = append(parts, fmt.Sprintf("ghostai.log tail:\n%s", tail))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, "; ") + ")"
 }
 
 // findGhostAI locates the ghostai binary.


### PR DESCRIPTION
Closes #320.

## Summary

Two distinct bugs in the bug-report log on issue #320, fixed together:

### Bug A — Test button always tried `qwen3.5-2b` regardless of saved model

User downloaded `qwen3.5-4b` via the wizard. The wizard correctly saved it (`SaveModel(GhostSpell Local, local, qwen3.5-4b)`). But clicking **Test** in Settings called `TestProviderConnection(local)`, which used `defaultTestModel(providerType)` — and `defaultTestModel` blindly returns `KnownModels[providerType][0]`, hardcoded to `qwen3.5-2b`. The test then failed with `model file not found: Qwen3.5-2B-Q4_K_M.gguf`, even though `Qwen3.5-4B-Q4_K_M.gguf` was right there on disk.

`gui/service_config.go:474-535` now walks `cfgCopy.Models` to find a saved entry whose `Provider` matches, and only falls back to `defaultTestModel` if **no** model has been saved yet (preserving the wizard's setup-page test flow, which intentionally runs before any model exists — see comment in `index.html:1851`).

### Bug B — Daemon spawn failure was undiagnosable

In the same log, after `SaveModel`, the wizard tried to start the daemon and failed within **87 ms**:

\`\`\`
[ghost-ai] starting daemon model=qwen3.5-4b threads=12 gpu_layers=99
Failed to init LLM client after wizard error="ghost-ai: daemon did not send ready message"
\`\`\`

87 ms is far too short to load a 2.6 GB model — the child process exited before writing one stdout line. But the error doesn't say *why*: missing binary, crashed on init, missing CUDA dep, model load failed — they all return the same string. \`cmd.Wait()\`'s exit code was being thrown away, and \`ghostai.log\` (where stderr goes) was never read.

\`llm/ghostai_client.go\` now captures \`cmd.Wait()\`'s exit code and tails the last 2 KB of \`ghostai.log\` into the error message. The same fix applies to the JSON-unmarshal failure path. Helpers \`ghostAILogPath\`, \`tailGhostAILog\`, and \`daemonFailureContext\` are added next to \`openGhostAILog\`.

This **does not fix** the underlying daemon-startup failure on the user's machine — we still don't know what is killing \`ghostai.exe\` in 87 ms. But the next bug report will tell us, instead of producing the same opaque string.

## Test plan

- [ ] Fresh install on a clean Windows VM, download \`qwen3.5-4b\` via wizard, click **Test** on the local provider in Settings → expect either success or a \`Qwen3.5-4B-Q4_K_M.gguf\` related error (not \`Qwen3.5-2B-Q4_K_M.gguf\`)
- [ ] Same flow with \`qwen3.5-0.8b\` and \`nemotron-nano-4b\` — Test should use whichever model was downloaded
- [ ] Wizard setup page (before any model is saved) — Test button should still work (falls back to \`defaultTestModel\`)
- [ ] Force a daemon failure (rename \`ghostai.exe\` between SaveModel and daemon start, or pass a bogus \`--gpu-layers\`) → confirm error message includes \`(exit N; ghostai.log tail: ...)\` with usable diagnostic info
- [ ] Existing TestProvider(label) path on the model card unchanged

## Notes

- Version bumped to **0.96.10.320** per the project's \`A.B.C.D\` rule (C=patch, D=issue/PR number).
- Architectural follow-up issue for the runtime-binary split (GPU runtime as a downloadable backend, à la Ollama / LM Studio) will be filed separately — that is the long-term fix for the "300 MB CUDA payload forced on every user" problem and is out of scope here.

Generated with Claude Code